### PR TITLE
Split subspaceWrappers into multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ When nesting subspaces, the `root` node will reflect the top most root state. Na
 
 ## Examples
 
-Example can be found [here](./examples).
+Examples can be found [here](./examples).
 
 ## Caveats
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,10 +3,10 @@ Redux Subspace Examples
 
 ## How to Run
 
-The examples require that the library distribution to already exist.  To create this run the following commands in the root directory:
+The examples requires that the library distribution already exists before they can be started.  To create this run the following commands in the root directory:
 
 ```
-npm run distribution
+npm run dist
 ```
 
 To run the examples, run the following commands:
@@ -19,4 +19,4 @@ npm install
 npm start
 ```
 
-The navigate your browser to `http://localhost:8080`
+Then navigate your browser to `http://localhost:8080`

--- a/examples/global-actions/app/App.jsx
+++ b/examples/global-actions/app/App.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../lib'
+import { Component } from '../component'
+import { ResetButton } from '../resetButton'
+
+export default props => {
+    return (
+        <div>
+            <h2>Global Actions</h2>
+            <SubspaceProvider mapState={state => state.component1} namespace="component1">
+                <Component />
+            </SubspaceProvider>
+            <SubspaceProvider mapState={state => state.component2} namespace="component2">
+                <Component />
+            </SubspaceProvider>
+            <SubspaceProvider mapState={state => state}>
+                <ResetButton />
+            </SubspaceProvider>
+        </div>
+    )
+}

--- a/examples/global-actions/component/Component.jsx
+++ b/examples/global-actions/component/Component.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { changeValue } from './actions'
+
+const Component = props => {
+  return (
+    <div>
+      <div>{props.value} <button onClick={() => props.changeValue()}>Change It!</button></div>
+    </div>
+  )
+}
+
+const mapStateToProps = state => {
+  return {
+    value: state.value
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    changeValue: () => dispatch(changeValue())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Component)

--- a/examples/global-actions/index.jsx
+++ b/examples/global-actions/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, compose } from 'redux'
+import { App, reducer } from './app'
+
+const store = createStore(reducer, compose(
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ))
+
+render(
+    <Provider store={store} >
+        <App />
+    </Provider>,
+    document.getElementById('content')
+)

--- a/examples/global-actions/webpack.config.js
+++ b/examples/global-actions/webpack.config.js
@@ -2,7 +2,7 @@ require('webpack');
 var path = require('path');
 
 module.exports = {
-    entry: ['./index.js'],
+    entry: ['./index.jsx'],
     output: {
         path: './dist',
         filename: 'bundle.js',

--- a/examples/namespaced-components/app/App.jsx
+++ b/examples/namespaced-components/app/App.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../lib'
+import { Component } from '../component'
+
+export default props => {
+    return (
+        <div>
+            <h2>Namespaced Components</h2>
+            <SubspaceProvider mapState={state => state.component1} namespace="component1">
+                <Component />
+            </SubspaceProvider>
+            <SubspaceProvider mapState={state => state.component2} namespace="component2">
+                <Component />
+            </SubspaceProvider>
+        </div>
+    )
+}

--- a/examples/namespaced-components/component/Component.jsx
+++ b/examples/namespaced-components/component/Component.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { changeValue } from './actions'
+
+const Component = props => {
+  return (
+    <div>
+      <div>{props.value} <button onClick={() => props.changeValue()}>Change It!</button></div>
+    </div>
+  )
+}
+
+const mapStateToProps = state => {
+  return {
+    value: state.value
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    changeValue: () => dispatch(changeValue())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Component)

--- a/examples/namespaced-components/index.jsx
+++ b/examples/namespaced-components/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, compose } from 'redux'
+import { App, reducer } from './app'
+
+const store = createStore(reducer, compose(
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ))
+
+render(
+    <Provider store={store} >
+        <App />
+    </Provider>,
+    document.getElementById('content')
+)

--- a/examples/namespaced-components/webpack.config.js
+++ b/examples/namespaced-components/webpack.config.js
@@ -2,7 +2,7 @@ require('webpack');
 var path = require('path');
 
 module.exports = {
-    entry: ['./index.js'],
+    entry: ['./index.jsx'],
     output: {
         path: './dist',
         filename: 'bundle.js',

--- a/examples/nested-components/app/App.jsx
+++ b/examples/nested-components/app/App.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../lib'
+import { Component } from '../component1'
+
+export default props => {
+    return (
+        <div>
+            <h2>Nested Components</h2>
+            <SubspaceProvider mapState={state => state.component}>
+                <Component />
+            </SubspaceProvider>
+        </div>
+    )
+}

--- a/examples/nested-components/component1/Component.jsx
+++ b/examples/nested-components/component1/Component.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../lib'
+import { Component as SubComponent } from '../component2'
+
+const Component = props => {
+  return (
+    <SubspaceProvider mapState={state => state.component}>
+        <SubComponent />
+    </SubspaceProvider>
+  )
+}
+
+export default Component

--- a/examples/nested-components/component2/Component.jsx
+++ b/examples/nested-components/component2/Component.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { changeValue } from './actions'
+
+const Component = props => {
+  return (
+    <div>
+      <div>{props.value} <button onClick={() => props.changeValue()}>Change It!</button></div>
+    </div>
+  )
+}
+
+const mapStateToProps = state => {
+  return {
+    value: state.value
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    changeValue: () => dispatch(changeValue())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Component)

--- a/examples/nested-components/index.jsx
+++ b/examples/nested-components/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, compose } from 'redux'
+import { App, reducer } from './app'
+
+const store = createStore(reducer, compose(
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ))
+
+render(
+    <Provider store={store} >
+        <App />
+    </Provider>,
+    document.getElementById('content')
+)

--- a/examples/nested-components/webpack.config.js
+++ b/examples/nested-components/webpack.config.js
@@ -2,7 +2,7 @@ require('webpack');
 var path = require('path');
 
 module.exports = {
-    entry: ['./index.js'],
+    entry: ['./index.jsx'],
     output: {
         path: './dist',
         filename: 'bundle.js',

--- a/examples/single-component/app/App.jsx
+++ b/examples/single-component/app/App.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../lib'
+import { Component } from '../component'
+
+export default props => {
+    return (
+        <div>
+            <h2>Single Component</h2>
+            <SubspaceProvider mapState={state => state.component}>
+                <Component />
+            </SubspaceProvider>
+        </div>
+    )
+}

--- a/examples/single-component/component/Component.jsx
+++ b/examples/single-component/component/Component.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { changeValue } from './actions'
+
+const Component = props => {
+  return (
+    <div>
+      <div>{props.value} <button onClick={() => props.changeValue()}>Change It!</button></div>
+    </div>
+  )
+}
+
+const mapStateToProps = state => {
+  return {
+    value: state.value
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    changeValue: () => dispatch(changeValue())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Component)

--- a/examples/single-component/index.jsx
+++ b/examples/single-component/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, compose } from 'redux'
+import { App, reducer } from './app'
+
+const store = createStore(reducer, compose(
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ))
+
+render(
+    <Provider store={store} >
+        <App />
+    </Provider>,
+    document.getElementById('content')
+)

--- a/examples/single-component/webpack.config.js
+++ b/examples/single-component/webpack.config.js
@@ -2,7 +2,7 @@ require('webpack');
 var path = require('path');
 
 module.exports = {
-    entry: ['./index.js'],
+    entry: ['./index.jsx'],
     output: {
         path: './dist',
         filename: 'bundle.js',

--- a/examples/thunks/app/App.jsx
+++ b/examples/thunks/app/App.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../lib'
+import { Component } from '../component'
+
+export default props => {
+    return (
+        <div>
+            <h2>Thunks</h2>
+            <SubspaceProvider mapState={state => state.component}>
+                <Component />
+            </SubspaceProvider>
+        </div>
+    )
+}

--- a/examples/thunks/component/Component.jsx
+++ b/examples/thunks/component/Component.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { changeValue } from './actions'
+
+const Component = props => {
+  return (
+    <div>
+      <div>{props.value} <button onClick={() => props.changeValue()}>Change It!</button></div>
+    </div>
+  )
+}
+
+const mapStateToProps = state => {
+  return {
+    value: state.value
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    changeValue: () => dispatch(changeValue())
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Component)

--- a/examples/thunks/index.jsx
+++ b/examples/thunks/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, applyMiddleware, compose } from 'redux'
+import thunk from 'redux-thunk'
+import { App, reducer } from './app'
+
+const store = createStore(reducer, compose(
+    applyMiddleware(thunk),
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ))
+
+render(
+    <Provider store={store} >
+        <App />
+    </Provider>,
+    document.getElementById('content')
+)

--- a/examples/thunks/webpack.config.js
+++ b/examples/thunks/webpack.config.js
@@ -2,7 +2,7 @@ require('webpack');
 var path = require('path');
 
 module.exports = {
-    entry: ['./index.js'],
+    entry: ['./index.jsx'],
     output: {
         path: './dist',
         filename: 'bundle.js',

--- a/examples/todos/app/App.jsx
+++ b/examples/todos/app/App.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../lib'
+import { TodoApp } from '../todoApp'
+
+export default props => {
+    return (
+        <div>
+            <h2>To-Do List</h2>
+            <SubspaceProvider mapState={state => state.todoApp}>
+                <TodoApp />
+            </SubspaceProvider>
+            <h2>Shopping List</h2>
+            <SubspaceProvider mapState={state => state.shoppingList} namespace="shoppingList">
+                <TodoApp />
+            </SubspaceProvider>
+        </div>
+    )
+}

--- a/examples/todos/filterFooter/components/Footer.jsx
+++ b/examples/todos/filterFooter/components/Footer.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import FilterLink from '../containers/FilterLink'
+
+const Footer = () => (
+  <p>
+    Show:
+    {" "}
+    <FilterLink filter="SHOW_ALL">
+      All
+    </FilterLink>
+    {", "}
+    <FilterLink filter="SHOW_ACTIVE">
+      Active
+    </FilterLink>
+    {", "}
+    <FilterLink filter="SHOW_COMPLETED">
+      Completed
+    </FilterLink>
+  </p>
+)
+
+export default Footer

--- a/examples/todos/filterFooter/components/Link.jsx
+++ b/examples/todos/filterFooter/components/Link.jsx
@@ -1,0 +1,26 @@
+import React, { PropTypes } from 'react'
+
+const Link = ({ active, children, onClick }) => {
+  if (active) {
+    return <span>{children}</span>
+  }
+
+  return (
+    <a href="#"
+       onClick={e => {
+         e.preventDefault()
+         onClick()
+       }}
+    >
+      {children}
+    </a>
+  )
+}
+
+Link.propTypes = {
+  active: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired
+}
+
+export default Link

--- a/examples/todos/index.jsx
+++ b/examples/todos/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, compose } from 'redux'
+import { App, reducer } from './app'
+
+const store = createStore(reducer, compose(
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ))
+
+render(
+    <Provider store={store} >
+        <App />
+    </Provider>,
+    document.getElementById('content')
+)

--- a/examples/todos/todoApp/components/Todo.jsx
+++ b/examples/todos/todoApp/components/Todo.jsx
@@ -1,0 +1,20 @@
+import React, { PropTypes } from 'react'
+
+const Todo = ({ onClick, completed, text }) => (
+  <li
+    onClick={onClick}
+    style={{
+      textDecoration: completed ? 'line-through' : 'none'
+    }}
+  >
+    {text}
+  </li>
+)
+
+Todo.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  completed: PropTypes.bool.isRequired,
+  text: PropTypes.string.isRequired
+}
+
+export default Todo

--- a/examples/todos/todoApp/components/TodoApp.jsx
+++ b/examples/todos/todoApp/components/TodoApp.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { SubspaceProvider } from '../../../../lib'
+import AddTodo from '../containers/AddTodo'
+import VisibleTodoList from '../containers/VisibleTodoList'
+import { Footer } from '../../filterFooter'
+
+const getVisibleTodos = (todos, filter) => {
+  switch (filter) {
+    case 'SHOW_ALL':
+      return todos
+    case 'SHOW_COMPLETED':
+      return todos.filter(t => t.completed)
+    case 'SHOW_ACTIVE':
+      return todos.filter(t => !t.completed)
+  }
+}
+
+const TodoApp = () => (
+  <div>
+    <AddTodo />
+    <VisibleTodoList />
+    <SubspaceProvider mapState={(state) => state.visibilityFilter}>
+      <Footer />
+    </SubspaceProvider>
+  </div>
+)
+
+export default TodoApp

--- a/examples/todos/todoApp/components/TodoList.jsx
+++ b/examples/todos/todoApp/components/TodoList.jsx
@@ -1,0 +1,40 @@
+import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
+import Todo from './Todo'
+
+const TodoList = ({ todos, onTodoClick }) => (
+  <ul>
+    {todos.map(todo =>
+      <Todo
+        key={todo.id}
+        {...todo}
+        onClick={() => onTodoClick(todo.id)}
+      />
+    )}
+  </ul>
+)
+
+TodoList.propTypes = {
+  todos: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    completed: PropTypes.bool.isRequired,
+    text: PropTypes.string.isRequired
+  }).isRequired).isRequired,
+  onTodoClick: PropTypes.func.isRequired
+}
+
+let mapStateToProps = (state) => {
+  return {
+    todos: state.todos
+  }
+}
+
+let mapDispatchToProps = (dispatch) => {
+  return {
+    onTodoClick: (id) => {
+      dispatch(toggleTodo(id))
+    }
+  }
+}
+
+export default TodoList

--- a/examples/todos/webpack.config.js
+++ b/examples/todos/webpack.config.js
@@ -2,7 +2,7 @@ require('webpack');
 var path = require('path');
 
 module.exports = {
-    entry: ['./index.js'],
+    entry: ['./index.jsx'],
     output: {
         path: './dist',
         filename: 'bundle.js',

--- a/lib/components/SubspaceProvider.js
+++ b/lib/components/SubspaceProvider.js
@@ -10,7 +10,9 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _react = require('react');
 
-var _subspaceWrappers = require('./subspaceWrappers');
+var _subState = require('../utils/subState');
+
+var _dispatch = require('../utils/dispatch');
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -37,17 +39,15 @@ var SubspaceProvider = function (_Component) {
         key: 'getChildContext',
         value: function getChildContext() {
             var rootStore = this.context.store;
-            var getState = (0, _subspaceWrappers.getSubState)(rootStore.getState, this.props.mapState);
-            var dispatch = (0, _subspaceWrappers.namespacedDispatch)(rootStore.dispatch, getState, this.props.namespace) || (0, _subspaceWrappers.subStateDispatch)(rootStore.dispatch, getState);
+            var getState = (0, _subState.getSubState)(rootStore.getState, this.props.mapState);
+            var dispatch = (0, _dispatch.namespacedDispatch)(rootStore.dispatch, getState, this.props.namespace) || (0, _dispatch.subStateDispatch)(rootStore.dispatch, getState);
 
             return { store: _extends({}, rootStore, { getState: getState, dispatch: dispatch }) };
         }
     }, {
         key: 'render',
         value: function render() {
-            var children = this.props.children;
-
-            return _react.Children.only(children);
+            return _react.Children.only(this.props.children);
         }
     }]);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,11 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.SubspaceProvider = exports.namespaced = undefined;
 
-var _subspaceWrappers = require('./subspaceWrappers');
+var _namespaced = require('./reducers/namespaced');
 
-var _SubspaceProvider = require('./SubspaceProvider');
+var _namespaced2 = _interopRequireDefault(_namespaced);
+
+var _SubspaceProvider = require('./components/SubspaceProvider');
 
 var _SubspaceProvider2 = _interopRequireDefault(_SubspaceProvider);
 
@@ -21,5 +23,5 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * LICENSE file in the root directory of this source tree.
  */
 
-exports.namespaced = _subspaceWrappers.namespacedReducer;
+exports.namespaced = _namespaced2.default;
 exports.SubspaceProvider = _SubspaceProvider2.default;

--- a/lib/reducers/namespaced.js
+++ b/lib/reducers/namespaced.js
@@ -1,0 +1,30 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+/**
+ * Copyright 2016, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+exports.default = function (reducer, namespace) {
+    return function (state, action) {
+        if (typeof state === 'undefined' || action.globalAction) {
+            return reducer(state, action);
+        }
+
+        if (action && action.type && action.type.indexOf(namespace + '/') === 0) {
+            var theAction = _extends({}, action, { type: action.type.substring(namespace.length + 1) });
+            return reducer(state, theAction);
+        }
+
+        return state;
+    };
+};

--- a/lib/utils/dispatch.js
+++ b/lib/utils/dispatch.js
@@ -6,8 +6,6 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 /**
  * Copyright 2016, IOOF Holdings Limited.
  * All rights reserved.
@@ -15,19 +13,6 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-var getSubState = exports.getSubState = function getSubState(getState, mapState) {
-    return function () {
-        var rootState = getState();
-        var subState = mapState(rootState);
-
-        if (subState && (typeof subState === 'undefined' ? 'undefined' : _typeof(subState)) === 'object' && !Array.isArray(subState)) {
-            return _extends({}, mapState(rootState), { root: rootState.root || rootState });
-        } else {
-            return subState;
-        }
-    };
-};
 
 var subStateDispatch = exports.subStateDispatch = function subStateDispatch(dispatch, getState) {
 
@@ -79,19 +64,4 @@ var namespacedDispatch = exports.namespacedDispatch = function namespacedDispatc
     };
 
     return wrapDispatch(dispatch, getState, namespace);
-};
-
-var namespacedReducer = exports.namespacedReducer = function namespacedReducer(reducer, namespace) {
-    return function (state, action) {
-        if (typeof state === 'undefined' || action.globalAction) {
-            return reducer(state, action);
-        }
-
-        if (action && action.type && action.type.indexOf(namespace + '/') === 0) {
-            var theAction = _extends({}, action, { type: action.type.substring(namespace.length + 1) });
-            return reducer(state, theAction);
-        }
-
-        return state;
-    };
 };

--- a/lib/utils/subState.js
+++ b/lib/utils/subState.js
@@ -1,0 +1,30 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+/**
+ * Copyright 2016, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var getSubState = exports.getSubState = function getSubState(getState, mapState) {
+    return function () {
+        var rootState = getState();
+        var subState = mapState(rootState);
+
+        if (subState && (typeof subState === 'undefined' ? 'undefined' : _typeof(subState)) === 'object' && !Array.isArray(subState)) {
+            return _extends({}, mapState(rootState), { root: rootState.root || rootState });
+        } else {
+            return subState;
+        }
+    };
+};

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "license": "BSD",
   "main": "lib/index.js",
   "scripts": {
-    "start": "webpack-dev-server --config demo/webpack.config.js --content-base demo/ --progress --profile --colors --port 8080",
-    "dist": "babel src --out-dir lib --ignore __tests__",
-    "test": "mocha mocha.setup $(find src -path '*-spec.js')"
+    "dist": "babel src --out-dir lib",
+    "test": "mocha --compilers js:babel-register --recursive --require ./test/setup.js",
+    "test:watch": "npm test -- --watch"
   },
   "repository": {
     "type": "git",

--- a/src/components/SubspaceProvider.js
+++ b/src/components/SubspaceProvider.js
@@ -7,7 +7,8 @@
  */
 
 import { Component, PropTypes, Children } from 'react'
-import { getSubState, subStateDispatch, namespacedDispatch } from './subspaceWrappers'
+import { getSubState } from '../utils/subState'
+import { subStateDispatch, namespacedDispatch } from '../utils/dispatch'
 
 export default class SubspaceProvider extends Component {
 
@@ -20,8 +21,7 @@ export default class SubspaceProvider extends Component {
     }
 
     render() {
-        const { children } = this.props
-        return Children.only(children)
+        return Children.only(this.props.children)
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { namespacedReducer as namespaced } from './subspaceWrappers'
-import SubspaceProvider from './SubspaceProvider'
+import namespaced from './reducers/namespaced'
+import SubspaceProvider from './components/SubspaceProvider'
 
 export {
     namespaced,

--- a/src/reducers/namespaced.js
+++ b/src/reducers/namespaced.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default (reducer, namespace) => {
+    return (state, action) => {
+        if (typeof state === 'undefined' || action.globalAction) {
+            return reducer(state, action)
+        }
+
+        if (action && action.type && action.type.indexOf(`${namespace}/`) === 0) {
+            let theAction = {...action, type: action.type.substring(namespace.length + 1)}
+            return reducer(state, theAction)
+        }
+
+        return state
+    }
+}

--- a/src/utils/dispatch.js
+++ b/src/utils/dispatch.js
@@ -6,17 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export const getSubState = (getState, mapState) => () => {
-    let rootState = getState();
-    let subState = mapState(rootState)
-
-    if (subState && typeof subState === 'object' && !Array.isArray(subState)) {
-        return { ...mapState(rootState), root: rootState.root || rootState }
-    } else {
-        return subState
-    }
-}
-
 export const subStateDispatch = (dispatch, getState) => {
 
     const wrapDispatch = (localDispatch) => {
@@ -60,19 +49,4 @@ export const namespacedDispatch = (dispatch, getState, namespace) => {
     }
 
     return wrapDispatch(dispatch, getState, namespace)
-}
-
-export const namespacedReducer = (reducer, namespace) => {
-    return (state, action) => {
-        if (typeof state === 'undefined' || action.globalAction) {
-            return reducer(state, action)
-        }
-
-        if (action && action.type && action.type.indexOf(`${namespace}/`) === 0) {
-            let theAction = {...action, type: action.type.substring(namespace.length + 1)}
-            return reducer(state, theAction)
-        }
-
-        return state
-    }
 }

--- a/src/utils/subState.js
+++ b/src/utils/subState.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2016, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const getSubState = (getState, mapState) => () => {
+    let rootState = getState();
+    let subState = mapState(rootState)
+
+    if (subState && typeof subState === 'object' && !Array.isArray(subState)) {
+        return { ...mapState(rootState), root: rootState.root || rootState }
+    } else {
+        return subState
+    }
+}

--- a/test/reducers/namespaced-spec.js
+++ b/test/reducers/namespaced-spec.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import namespaced from '../../src/reducers/namespaced'
+
+describe('namespaced Tests', () => {
+
+    const initialState = "initial state"
+    const testReducer = (state = initialState, action) => {
+        switch (action.type) {
+            case "CHANGE_STATE":
+                return action.newValue
+            default:
+                return state
+        }
+    }
+    const wrappedReducer = namespaced(testReducer, "testing")
+
+    it('should get initial state from wrapped reducer', () => {
+        let action = { type: "INIT" }
+        let newState = wrappedReducer(undefined, action)
+        expect(newState).to.equal('initial state')
+    })
+
+    it('should ignore action without provided namespace', () => {
+        let action = { type: "CHANGE_STATE", newValue: "new state" }
+        let newState = wrappedReducer(initialState, action)
+        expect(newState).to.equal('initial state')
+    })
+
+    it('should forward action with provided namespace', () => {
+        let action = { type: "testing/CHANGE_STATE", newValue: "new state" }
+        let newState = wrappedReducer(initialState, action)
+        expect(newState).to.equal('new state')
+    })
+
+    it('should forward global actions', () => {
+        let action = { type: "CHANGE_STATE", newValue: "new state", globalAction: true }
+        let newState = wrappedReducer(initialState, action)
+        expect(newState).to.equal('new state')
+    })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,11 @@
+/**
+ * Copyright 2016, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 require('babel-register')(
     {
         babelrc: false,

--- a/test/utils/dispatch-spec.js
+++ b/test/utils/dispatch-spec.js
@@ -6,78 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { getSubState, subStateDispatch, namespacedDispatch, namespacedReducer } from '../subspaceWrappers'
+import { subStateDispatch, namespacedDispatch } from '../../src/utils/dispatch'
 
-describe('subspaceWrappers Tests', () => {
-    describe('getSubState Tests', () => {
-        it('should create sub-state', () => {
-            let state = {
-                state1: {
-                    key: 'expected'
-                },
-                state2: {
-                    key: 'wrong'
-                }
-            }
-
-            let subState = getSubState(() => state, state => state.state1)()
-
-            expect(subState.key).to.equal('expected')
-            expect(subState.root).to.equal(state)
-        })
-
-        it('should use existing root node', () => {
-            let state = {
-                state1: {
-                    key: 'expected'
-                },
-                state2: {
-                    key: 'wrong'
-                },
-                root: {
-                    states: {
-                        state1: {
-                            key: 'expected'
-                        },
-                        state2: {
-                            key: 'wrong'
-                        }
-                    }
-                }
-            }
-
-            let subState = getSubState(() => state, state => state.state1)()
-
-            expect(subState.key).to.equal('expected')
-            expect(subState.root).to.equal(state.root)
-        })
-
-        it('should not modify sub-state if primitive value', () => {
-            let state = {
-                state1: 'expected',
-                state2: 'wrong'
-            }
-
-            let subState = getSubState(() => state, state => state.state1)()
-
-            expect(subState).to.equal('expected')
-            expect(subState.root).to.be.undefined
-        })
-
-        it('should not modify sub-state if array value', () => {
-            let state = {
-                state1: ['expected'],
-                state2: ['wrong']
-            }
-
-            let subState = getSubState(() => state, state => state.state1)()
-
-            expect(subState).to.deep.equal(['expected'])
-            expect(subState.root).to.be.undefined
-        })
-    })
-
-    describe('subStateDispatch Tests', () => {
+describe('dispatch Tests', () => {
+    describe('subStateDispatch', () => {
         it('should forward standard action to dispatch', () => {
             let dispatch = sinon.spy()
             let state = { value: "test" }
@@ -218,7 +150,7 @@ describe('subspaceWrappers Tests', () => {
         })
     })
 
-    describe('namespacedDispatch Tests', () => {
+    describe('namespacedDispatch', () => {
         it('should not wrap dispatch in namespace is not provided', () => {
             let dispatch = sinon.spy()
             let state = { value: "test" }
@@ -362,44 +294,6 @@ describe('subspaceWrappers Tests', () => {
             namespacedDispatch(dispatch, () => state, 'customNamespace')(action)
 
             expect(dispatch).to.have.been.calledWith(action)
-        })
-    })
-
-    describe('namespacedReducer Tests', () => {
-
-        const initialState = "initial state"
-        const testReducer = (state = initialState, action) => {
-            switch (action.type) {
-                case "CHANGE_STATE":
-                    return action.newValue
-                default:
-                    return state
-            }
-        }
-        const wrappedReducer = namespacedReducer(testReducer, "testing")
-
-        it('should get initial state from wrapped reducer', () => {
-            let action = { type: "INIT" }
-            let newState = wrappedReducer(undefined, action)
-            expect(newState).to.equal('initial state')
-        })
-
-        it('should ignore action without provided namespace', () => {
-            let action = { type: "CHANGE_STATE", newValue: "new state" }
-            let newState = wrappedReducer(initialState, action)
-            expect(newState).to.equal('initial state')
-        })
-
-        it('should forward action with provided namespace', () => {
-            let action = { type: "testing/CHANGE_STATE", newValue: "new state" }
-            let newState = wrappedReducer(initialState, action)
-            expect(newState).to.equal('new state')
-        })
-
-        it('should forward global actions', () => {
-            let action = { type: "CHANGE_STATE", newValue: "new state", globalAction: true }
-            let newState = wrappedReducer(initialState, action)
-            expect(newState).to.equal('new state')
         })
     })
 })

--- a/test/utils/subState-spec.js
+++ b/test/utils/subState-spec.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016, IOOF Holdings Limited.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { getSubState } from '../../src/utils/subState'
+
+describe('subState Tests', () => {
+    describe('getSubState', () => {
+        it('should create sub-state', () => {
+            let state = {
+                state1: {
+                    key: 'expected'
+                },
+                state2: {
+                    key: 'wrong'
+                }
+            }
+
+            let subState = getSubState(() => state, state => state.state1)()
+
+            expect(subState.key).to.equal('expected')
+            expect(subState.root).to.equal(state)
+        })
+
+        it('should use existing root node', () => {
+            let state = {
+                state1: {
+                    key: 'expected'
+                },
+                state2: {
+                    key: 'wrong'
+                },
+                root: {
+                    states: {
+                        state1: {
+                            key: 'expected'
+                        },
+                        state2: {
+                            key: 'wrong'
+                        }
+                    }
+                }
+            }
+
+            let subState = getSubState(() => state, state => state.state1)()
+
+            expect(subState.key).to.equal('expected')
+            expect(subState.root).to.equal(state.root)
+        })
+
+        it('should not modify sub-state if primitive value', () => {
+            let state = {
+                state1: 'expected',
+                state2: 'wrong'
+            }
+
+            let subState = getSubState(() => state, state => state.state1)()
+
+            expect(subState).to.equal('expected')
+            expect(subState.root).to.be.undefined
+        })
+
+        it('should not modify sub-state if array value', () => {
+            let state = {
+                state1: ['expected'],
+                state2: ['wrong']
+            }
+
+            let subState = getSubState(() => state, state => state.state1)()
+
+            expect(subState).to.deep.equal(['expected'])
+            expect(subState.root).to.be.undefined
+        })
+    })
+})


### PR DESCRIPTION
This resolves #6.
Restructed code to better define functionality boundaries by splitting the subspaceWrappers file and organised them similarly to the react-redux repo.
Moved tests from individual __tests__ folders to a test folder in the repo root and changed scripts accourdingly.
Removed start script from root package.json as it was not working in its current state.
Changed extension of files containing jsx to .jsx