### PR TITLE
Add TravisCI build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "6"


### PR DESCRIPTION
Basic config to build and test the project against nodejs 6.x.

Runs `npm install` and `npm test` as per TravisCI defaults.