### PR TITLE
Provide root state as second parameter to mapState

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ For a Redux connected React component, SubspaceProvider allows you to present a 
 
 Actions dispatched from components can be automatically namespaced to prevent them from being picked up by unrelated reducers that inadvertently use the same action types. Actions dispatched inside thunks executed by Redux-thunk middleware will be automatically namespaced.
 
-Subspace works with global actions by specifying `global: true` in the action. Global actions will not be namespaced, allowing them to be picked up by other components' reducers.
-
 ## Use this library if...
   * You are using a single global Redux store, but would like to create decoupled and sharable Redux components.
   * You want actions dispatched from these components to not be picked up by reducers in other components (i.e. avoid action cross talk).
@@ -45,6 +43,14 @@ import { SubComponent } from 'some-dependency'
 ...
 
 <SubspaceProvider mapState={state => state.subComponent}>
+    <SubComponent />
+</SubspaceProvider>
+```
+
+The root state of the store is also provided as a second parameter to `mapState` as well.  This can be useful for accessing global in nested components (e.g. configuration).
+
+```
+<SubspaceProvider mapState={(state, rootState) => ({ ...state.subComponent, configuration: rootState.configuration })>
     <SubComponent />
 </SubspaceProvider>
 ```

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   ],
   "license": "BSD",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "scripts": {
-    "dist": "babel src --out-dir lib",
+    "dist": "babel src --out-dir lib --copy-files",
     "lint": "eslint . --ext .js --ext .jsx",
     "lint:fix": "eslint . --ext .js --ext .jsx --fix",
     "test": "nyc --reporter=text --reporter=lcov mocha --compilers js:babel-register --recursive --require ./test/setup.js",
@@ -25,6 +26,7 @@
     "react": ">= 15.1"
   },
   "devDependencies": {
+    "@types/react": "^15.0.0",
     "babel-cli": "^6.18.0",
     "babel-core": " ^6.7.7",
     "babel-eslint": "^6.0.4",
@@ -46,6 +48,8 @@
     "redux": "^3.6.0",
     "redux-mock-store": "^1.2.1",
     "sinon": "^1.17.3",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "typescript": "^2.1.5",
+    "typescript-definition-tester": "0.0.5"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,7 @@ interface GlobalActionsRegister {
     isGlobal(action: Redux.Action): boolean;
 }
 
-export function makeGlobal(action: Redux.Action): Redux.Action;
+export function asGlobal(action: Redux.Action): Redux.Action ;
 
 export const GlobalActions: GlobalActionsRegister
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ export function namespaced<S>(state: Redux.Reducer<S>, namespace: string): Redux
  */
 
 interface MapState{
-    <TParentState>(state: TParentState): any;
+    <TParentState, TRootState>(state: TParentState, rootState: TRootState): any;
 }
 
 interface ComponentDecorator {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import * as Redux from 'redux';
+
+/**
+ * Actions
+ */
+interface GlobalActionsRegister {
+    register(type: string): GlobalActionsRegister;
+    isGlobal(action: Redux.Action): boolean;
+}
+
+export function makeGlobal(action: Redux.Action): Redux.Action;
+
+export const GlobalActions: GlobalActionsRegister
+
+/**
+ * Reducers
+ */
+export function namespaced<S>(state: Redux.Reducer<S>, namespace: string): Redux.Reducer<S>;
+
+/**
+ * Components
+ */
+
+interface MapState{
+    <TParentState>(state: TParentState): any;
+}
+
+interface ComponentDecorator {
+    <TProps, TComponentConstruct extends (React.ComponentClass<TProps> | React.StatelessComponent<TProps>)>(component: TComponentConstruct): TComponentConstruct;
+}
+
+export function subspaced(mapState: MapState): ComponentDecorator;
+export function subspaced(mapState: MapState, namespace: string): ComponentDecorator;
+
+export interface SubspaceProviderProps {
+    mapState: MapState;
+    namespace?: string;
+    children?: React.ReactNode;
+}
+
+export class SubspaceProvider extends React.Component<SubspaceProviderProps, void> { }

--- a/src/utils/subState.js
+++ b/src/utils/subState.js
@@ -7,15 +7,16 @@
  */
 
 export const getSubState = (getState, mapState) => () => {
-    let rootState = getState()
-    let subState = mapState(rootState)
+    let parentState = getState()
+    let rootState = parentState.root || parentState
+    let subState = mapState(parentState, rootState)
 
     if (process.env.NODE_ENV !== 'production') {
         console.assert(subState !== undefined, 'mapState must not return undefined.')
     }
 
     if (typeof subState === 'object' && !Array.isArray(subState)) {
-        return { ...subState, root: rootState.root || rootState }
+        return { ...subState, root: rootState }
     } else {
         return subState
     }

--- a/test/typescript/definitions-spec.js
+++ b/test/typescript/definitions-spec.js
@@ -1,0 +1,23 @@
+import * as ts from 'typescript'
+import * as tt from 'typescript-definition-tester'
+
+describe('TypeScript definitions', function () {
+
+  const options = {
+    noEmitOnError: true,
+    noImplicitAny: true,
+    target: ts.ScriptTarget.ES5,
+    module: ts.ModuleKind.CommonJS,
+    jsx: ts.JsxEmit.React
+  }
+
+  it('should compile against index.d.ts', (done) => {
+
+    tt.compileDirectory(
+      __dirname + '/definitions',
+      fileName => fileName.match(/\.tsx?$/),
+      options,
+      () => done()
+    )
+  })
+})

--- a/test/typescript/definitions/GlobalActions.ts
+++ b/test/typescript/definitions/GlobalActions.ts
@@ -1,0 +1,7 @@
+import { GlobalActions } from '../../../src'
+
+GlobalActions.register("TEST_ACTION_1").register("TEST_ACTION_2")
+
+const action = { type: "TEST_ACTION" }
+
+const isGlobal = GlobalActions.isGlobal(action)

--- a/test/typescript/definitions/SubspaceProvider.tsx
+++ b/test/typescript/definitions/SubspaceProvider.tsx
@@ -9,6 +9,10 @@ class ParentState {
     child: ChildState
 }
 
+class RootState {
+    parent: ParentState
+}
+
 const TestComponent = () => {
     return (
         <SubspaceProvider mapState={(state: ParentState) => state.child}>
@@ -20,6 +24,22 @@ const TestComponent = () => {
 const TestNamepsacedComponent = () => {
     return (
         <SubspaceProvider mapState={(state: ParentState) => state.child} namespace="testNamespace">
+            <p>test</p>
+        </SubspaceProvider>
+    )
+}
+
+const TestComponentWithRootState = () => {
+    return (
+        <SubspaceProvider mapState={(state: ParentState, rootState: RootState) => ({ ...state.child, ...rootState.parent })}>
+            <p>test</p>
+        </SubspaceProvider>
+    )
+}
+
+const TestNamepsacedComponentWithRootState = () => {
+    return (
+        <SubspaceProvider mapState={(state: ParentState, rootState: RootState) => ({ ...state.child, ...rootState.parent })} namespace="testNamespace">
             <p>test</p>
         </SubspaceProvider>
     )

--- a/test/typescript/definitions/SubspaceProvider.tsx
+++ b/test/typescript/definitions/SubspaceProvider.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { SubspaceProvider } from '../../../src'
+
+class ChildState {
+    value: any
+}
+
+class ParentState {
+    child: ChildState
+}
+
+const TestComponent = () => {
+    return (
+        <SubspaceProvider mapState={(state: ParentState) => state.child}>
+            <p>test</p>
+        </SubspaceProvider>
+    )
+}
+
+const TestNamepsacedComponent = () => {
+    return (
+        <SubspaceProvider mapState={(state: ParentState) => state.child} namespace="testNamespace">
+            <p>test</p>
+        </SubspaceProvider>
+    )
+}

--- a/test/typescript/definitions/asGlobal.ts
+++ b/test/typescript/definitions/asGlobal.ts
@@ -1,0 +1,6 @@
+import { Action } from 'redux'
+import { asGlobal } from '../../../src'
+
+const action = { type: "TEST_ACTION" }
+
+const globalAction = asGlobal(action)

--- a/test/typescript/definitions/makeGlobal.ts
+++ b/test/typescript/definitions/makeGlobal.ts
@@ -1,6 +1,0 @@
-import { Action } from 'redux'
-import { makeGlobal } from '../../../src'
-
-const action = { type: "TEST_ACTION" }
-
-const globalAction = makeGlobal(action)

--- a/test/typescript/definitions/makeGlobal.ts
+++ b/test/typescript/definitions/makeGlobal.ts
@@ -1,0 +1,6 @@
+import { Action } from 'redux'
+import { makeGlobal } from '../../../src'
+
+const action = { type: "TEST_ACTION" }
+
+const globalAction = makeGlobal(action)

--- a/test/typescript/definitions/namespaced.ts
+++ b/test/typescript/definitions/namespaced.ts
@@ -1,0 +1,7 @@
+import { namespaced } from '../../../src'
+
+const reducer = (state = "test") => {
+    return state
+}
+
+const namespacedReducer = namespaced(reducer, "testNamespace");

--- a/test/typescript/definitions/subspaced.tsx
+++ b/test/typescript/definitions/subspaced.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { subspaced } from '../../../src'
+
+class ChildState {
+    value: any
+}
+
+class ParentState {
+    child: ChildState
+}
+
+class TestProps {
+    value: string
+}
+
+class StandardComponent extends React.Component<TestProps, void> {
+    render() {
+        return <p>{this.props.value}</p>
+    }
+}
+
+const StatelessComponent: React.StatelessComponent<TestProps> = (props) => <p>props.value</p>
+
+const SubspacedStandardComponent = subspaced((state: ParentState) => state.child)(StandardComponent)
+const NamespacedStandardComponent = subspaced((state: ParentState) => state.child, "testNamespace")(StandardComponent)
+const SubspacedStatelessComponent = subspaced((state: ParentState) => state.child)(StatelessComponent)
+const NamespacedStatelessComponent = subspaced((state: ParentState) => state.child, "testNamespace")(StatelessComponent)
+
+const Rendered: React.StatelessComponent<void> = () => {
+    return (
+        <div>
+            <SubspacedStandardComponent value="test" />
+            <NamespacedStandardComponent value="test" />
+            <SubspacedStatelessComponent value="test" />
+            <NamespacedStatelessComponent value="test" />
+        </div>
+    )
+}

--- a/test/typescript/definitions/subspaced.tsx
+++ b/test/typescript/definitions/subspaced.tsx
@@ -9,6 +9,10 @@ class ParentState {
     child: ChildState
 }
 
+class RootState {
+    parent: ParentState
+}
+
 class TestProps {
     value: string
 }
@@ -26,6 +30,11 @@ const NamespacedStandardComponent = subspaced((state: ParentState) => state.chil
 const SubspacedStatelessComponent = subspaced((state: ParentState) => state.child)(StatelessComponent)
 const NamespacedStatelessComponent = subspaced((state: ParentState) => state.child, "testNamespace")(StatelessComponent)
 
+const SubspacedStandardComponentWithRoot = subspaced((state: ParentState, rootState: RootState) => ({ ...state.child, ...rootState.parent }))(StandardComponent)
+const NamespacedStandardComponentWithRoot = subspaced((state: ParentState, rootState: RootState) => ({ ...state.child, ...rootState.parent }), "testNamespace")(StandardComponent)
+const SubspacedStatelessComponentWithRoot = subspaced((state: ParentState, rootState: RootState) => ({ ...state.child, ...rootState.parent }))(StatelessComponent)
+const NamespacedStatelessComponentWithRoot = subspaced((state: ParentState, rootState: RootState) => ({ ...state.child, ...rootState.parent }), "testNamespace")(StatelessComponent)
+
 const Rendered: React.StatelessComponent<void> = () => {
     return (
         <div>
@@ -33,6 +42,10 @@ const Rendered: React.StatelessComponent<void> = () => {
             <NamespacedStandardComponent value="test" />
             <SubspacedStatelessComponent value="test" />
             <NamespacedStatelessComponent value="test" />
+            <SubspacedStandardComponentWithRoot value="test" />
+            <NamespacedStandardComponentWithRoot value="test" />
+            <SubspacedStatelessComponentWithRoot value="test" />
+            <NamespacedStatelessComponentWithRoot value="test" />
         </div>
     )
 }

--- a/test/utils/subState-spec.js
+++ b/test/utils/subState-spec.js
@@ -52,6 +52,48 @@ describe('subState Tests', () => {
             expect(subState.root).to.equal(state.root)
         })
 
+        it('should provide parent state as root state when mapping', () => {
+            let state = {
+                state1: {
+                    key1: 1
+                },
+                state2: {
+                    key2: 2
+                }
+            }
+
+            let subState = getSubState(() => state, (state, rootState) => ({ ...state.state1, ...rootState.state2 }))()
+
+            expect(subState.key1).to.equal(1)
+            expect(subState.key2).to.equal(2)
+            expect(subState.root).to.equal(state)
+        })
+
+        it('should provide root state as root state when mapping', () => {
+            let state = {
+                state1: {
+                    key1: 1
+                },
+                state2: {
+                    key2: 2
+                },
+                root: {
+                    state1: {
+                        key1: 3
+                    },
+                    state2: {
+                        key2: 4
+                    }
+                }
+            }
+
+            let subState = getSubState(() => state, (state, rootState) => ({ ...state.state1, ...rootState.state2 }))()
+
+            expect(subState.key1).to.equal(1)
+            expect(subState.key2).to.equal(4)
+            expect(subState.root).to.equal(state.root)
+        })
+
         it('should not modify sub-state if primitive value', () => {
             let state = {
                 state1: 'expected',


### PR DESCRIPTION
Having to constantly check if `state.root` exists is annoying and reduces our ability to refactor the `root` node out in the future.  Providing the `rootState` to the mapState function simplifies both.

I have also included TypeScript definitions for subspace in this PR.