### PR TITLE
Improved `rootState` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Redux Subspace Library
 -----------------------
 
+[![npm version](https://img.shields.io/npm/v/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace) 
+[![npm downloads](https://img.shields.io/npm/dm/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace.svg?style=flat-square)](LICENSE)
+
 This is a library to create subspaces for Redux connected React components. It's designed to work with Provider from the [react-redux](https://github.com/reactjs/react-redux) bindings.
 
 The MelbJS presentation that launched this library - [Scaling React and Redux at IOOF](http://www.slideshare.net/VivianFarrell/scaling-react-and-redux-at-ioof).

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prop-types": "^15.5.0"
   },
   "peerDependencies": {
-    "react": ">= 15.1"
+    "react": ">= 15.1",
+    "react-redux": ">= 5.0.4"
   },
   "devDependencies": {
     "@types/react": "^15.0.0",

--- a/src/components/SubspaceProvider.js
+++ b/src/components/SubspaceProvider.js
@@ -14,11 +14,12 @@ import { subStateDispatch } from '../utils/dispatch'
 export default class SubspaceProvider extends Component {
 
     getChildContext() {
-        let rootStore = this.context.store
-        let getState = getSubState(rootStore.getState, this.props.mapState)
-        let dispatch = subStateDispatch(rootStore.dispatch, getState, this.props.namespace)
+        let parentStore = this.context.store
+        let rootStore = parentStore.rootStore || parentStore
+        let getState = getSubState(parentStore.getState, rootStore.getState, this.props.mapState)
+        let dispatch = subStateDispatch(parentStore.dispatch, getState, this.props.namespace)
 
-        return { store: { ...rootStore, getState, dispatch } }
+        return { store: { ...parentStore, getState, dispatch, rootStore } }
     }
 
     render() {

--- a/src/components/SubspaceProvider.js
+++ b/src/components/SubspaceProvider.js
@@ -14,10 +14,10 @@ import { subStateDispatch } from '../utils/dispatch'
 export default class SubspaceProvider extends Component {
 
     getChildContext() {
-        let parentStore = this.context.store
-        let rootStore = parentStore.rootStore || parentStore
-        let getState = getSubState(parentStore.getState, rootStore.getState, this.props.mapState)
-        let dispatch = subStateDispatch(parentStore.dispatch, getState, this.props.namespace)
+        const parentStore = this.context.store
+        const rootStore = parentStore.rootStore || parentStore
+        const getState = getSubState(parentStore.getState, rootStore.getState, this.props.mapState)
+        const dispatch = subStateDispatch(parentStore.dispatch, getState, this.props.namespace)
 
         return { store: { ...parentStore, getState, dispatch, rootStore } }
     }

--- a/src/components/subspaced.js
+++ b/src/components/subspaced.js
@@ -9,14 +9,21 @@
 import React from 'react'
 import SubspaceProvider from './SubspaceProvider'
 
-export default (mapState, namespace = undefined) => (Component) => {
-    const SubspacedComponent = (props) => {
-        return (
-            <SubspaceProvider mapState={mapState} namespace={namespace}>
-                <Component {...props} />
-            </SubspaceProvider>
-        )
-    }
+export default (mapState, namespace = undefined) => (WrappedComponent) => {
+
+    const wrappedComponentName = WrappedComponent.displayName
+        || WrappedComponent.name
+        || 'Component'
+
+    const displayName = `Subspaced(${wrappedComponentName})`
+
+    const SubspacedComponent = (props) => (
+        <SubspaceProvider mapState={mapState} namespace={namespace}>
+            <WrappedComponent {...props} />
+        </SubspaceProvider>
+    )
+
+    SubspacedComponent.displayName = displayName
 
     return SubspacedComponent
 }

--- a/src/utils/subState.js
+++ b/src/utils/subState.js
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export const getSubState = (getState, mapState) => () => {
+export const getSubState = (getState, getRootState, mapState) => () => {
     let parentState = getState()
-    let rootState = parentState.root || parentState
+    let rootState = getRootState()
     let subState = mapState(parentState, rootState)
 
     if (process.env.NODE_ENV !== 'production') {

--- a/test/components/SubspaceProvider-spec.js
+++ b/test/components/SubspaceProvider-spec.js
@@ -85,7 +85,7 @@ describe('SubspaceProvider Tests', () => {
         expect(testComponent.html()).to.equal("<p>expected 1 - expected 2</p>")
     })
 
-    it('should render child component with substate using root state', () => {
+    it('should render nested child component with substate using root state', () => {
         let state = {
             subState: {
                 subSubState: {

--- a/test/components/SubspaceProvider-spec.js
+++ b/test/components/SubspaceProvider-spec.js
@@ -37,4 +37,77 @@ describe('SubspaceProvider Tests', () => {
 
         expect(testComponent.html()).to.equal("<p>expected</p>")
     })
+
+    it('should render nested child component with substate', () => {
+        let state = {
+            subState: {
+                subSubState: {
+                    value: "expected"
+                },
+                value: "still wrong"
+            },
+            value: "wrong"
+        }
+
+        let mockStore = configureStore()(state)
+
+        let testComponent = render(
+            <Provider store={mockStore}>
+                <SubspaceProvider mapState={state => state.subState}>
+                    <SubspaceProvider mapState={state => state.subSubState}>
+                        <TestComponent />
+                    </SubspaceProvider>
+                </SubspaceProvider>
+            </Provider>
+        )
+
+        expect(testComponent.html()).to.equal("<p>expected</p>")
+    })
+
+    it('should render child component with substate using root state', () => {
+        let state = {
+            subState: {
+                value: "expected 1"
+            },
+            value: "expected 2"
+        }
+
+        let mockStore = configureStore()(state)
+
+        let testComponent = render(
+            <Provider store={mockStore}>
+                <SubspaceProvider mapState={(state, rootState) => ({ value: `${state.subState.value} - ${rootState.value}`})}>
+                    <TestComponent />
+                </SubspaceProvider>
+            </Provider>
+        )
+
+        expect(testComponent.html()).to.equal("<p>expected 1 - expected 2</p>")
+    })
+
+    it('should render child component with substate using root state', () => {
+        let state = {
+            subState: {
+                subSubState: {
+                    value: "expected 1"
+                },
+                value: "wrong"
+            },
+            value: "expected 2"
+        }
+
+        let mockStore = configureStore()(state)
+
+        let testComponent = render(
+            <Provider store={mockStore}>
+                <SubspaceProvider mapState={(state) => state.subState}>
+                    <SubspaceProvider mapState={(state, rootState) => ({ value: `${state.subSubState.value} - ${rootState.value}`})}>
+                        <TestComponent />
+                    </SubspaceProvider>
+                </SubspaceProvider>
+            </Provider>
+        )
+
+        expect(testComponent.html()).to.equal("<p>expected 1 - expected 2</p>")
+    })
 })

--- a/test/components/subspaced-spec.js
+++ b/test/components/subspaced-spec.js
@@ -62,4 +62,33 @@ describe('subspaced Tests', () => {
 
         expect(testComponent.html()).to.equal("<p>expected - something else</p>")
     })
+
+    it('should use component display name in display name', () => {
+        class TestComponent extends React.Component {
+            render() {
+                return null;
+            }
+        }
+
+        TestComponent.displayName = 'Connected(TestComponent)'
+
+        const SubspacedComponent = subspaced(state => state)(TestComponent)
+
+        expect(SubspacedComponent.displayName).to.equal("Subspaced(Connected(TestComponent))")
+    })
+
+    it('should use component name in display name', () => {
+        const TestComponent = () => null
+
+        const SubspacedComponent = subspaced(state => state)(TestComponent)
+
+        expect(SubspacedComponent.displayName).to.equal("Subspaced(TestComponent)")
+    })
+
+    it('should use fallback in display name', () => {
+
+        const SubspacedComponent = subspaced(state => state)('div')
+
+        expect(SubspacedComponent.displayName).to.equal("Subspaced(Component)")
+    })
 })

--- a/test/components/subspaced-spec.js
+++ b/test/components/subspaced-spec.js
@@ -63,6 +63,30 @@ describe('subspaced Tests', () => {
         expect(testComponent.html()).to.equal("<p>expected - something else</p>")
     })
 
+    it('should render subspaced component using root state', () => {
+        const TestComponent = connect(state => { return { value: state.value } })(props => (
+            <p>{props.value}</p>
+        ))
+        const SubspacedComponent = subspaced((state, rootState) => ({ value: `${state.subState.value} - ${rootState.value}`}))(TestComponent)
+
+        let state = {
+            subState: {
+                value: "expected 1"
+            },
+            value: "expected 2"
+        }
+
+        let mockStore = configureStore()(state)
+
+        let testComponent = render(
+            <Provider store={mockStore}>
+                <SubspacedComponent />
+            </Provider>
+        )
+
+        expect(testComponent.html()).to.equal("<p>expected 1 - expected 2</p>")
+    })
+
     it('should use component display name in display name', () => {
         class TestComponent extends React.Component {
             render() {

--- a/test/utils/subState-spec.js
+++ b/test/utils/subState-spec.js
@@ -20,7 +20,9 @@ describe('subState Tests', () => {
                 }
             }
 
-            let subState = getSubState(() => state, state => state.state1)()
+            let rootState = state
+
+            let subState = getSubState(() => state, () => rootState, state => state.state1)()
 
             expect(subState.key).to.equal('expected')
             expect(subState.root).to.equal(state)
@@ -33,9 +35,11 @@ describe('subState Tests', () => {
                 },
                 state2: {
                     key: 'wrong'
-                },
-                root: {
-                    states: {
+                }
+            }
+
+            let rootState = {
+                states: {
                         state1: {
                             key: 'expected'
                         },
@@ -43,13 +47,12 @@ describe('subState Tests', () => {
                             key: 'wrong'
                         }
                     }
-                }
             }
 
-            let subState = getSubState(() => state, state => state.state1)()
+            let subState = getSubState(() => state, () => rootState, state => state.state1)()
 
             expect(subState.key).to.equal('expected')
-            expect(subState.root).to.equal(state.root)
+            expect(subState.root).to.equal(rootState)
         })
 
         it('should provide parent state as root state when mapping', () => {
@@ -62,7 +65,9 @@ describe('subState Tests', () => {
                 }
             }
 
-            let subState = getSubState(() => state, (state, rootState) => ({ ...state.state1, ...rootState.state2 }))()
+            let rootState = state
+
+            let subState = getSubState(() => state, () => rootState, (state, rootState) => ({ ...state.state1, ...rootState.state2 }))()
 
             expect(subState.key1).to.equal(1)
             expect(subState.key2).to.equal(2)
@@ -76,8 +81,10 @@ describe('subState Tests', () => {
                 },
                 state2: {
                     key2: 2
-                },
-                root: {
+                }
+            }
+
+            let rootState = {
                     state1: {
                         key1: 3
                     },
@@ -85,13 +92,12 @@ describe('subState Tests', () => {
                         key2: 4
                     }
                 }
-            }
 
-            let subState = getSubState(() => state, (state, rootState) => ({ ...state.state1, ...rootState.state2 }))()
+            let subState = getSubState(() => state, () => rootState, (state, rootState) => ({ ...state.state1, ...rootState.state2 }))()
 
             expect(subState.key1).to.equal(1)
             expect(subState.key2).to.equal(4)
-            expect(subState.root).to.equal(state.root)
+            expect(subState.root).to.equal(rootState)
         })
 
         it('should not modify sub-state if primitive value', () => {
@@ -100,7 +106,9 @@ describe('subState Tests', () => {
                 state2: 'wrong'
             }
 
-            let subState = getSubState(() => state, state => state.state1)()
+            let rootState = state
+
+            let subState = getSubState(() => state, () => rootState, state => state.state1)()
 
             expect(subState).to.equal('expected')
             expect(subState.root).to.be.undefined
@@ -112,7 +120,9 @@ describe('subState Tests', () => {
                 state2: ['wrong']
             }
 
-            let subState = getSubState(() => state, state => state.state1)()
+            let rootState = state
+
+            let subState = getSubState(() => state, () => rootState, state => state.state1)()
 
             expect(subState).to.deep.equal(['expected'])
             expect(subState.root).to.be.undefined
@@ -123,7 +133,9 @@ describe('subState Tests', () => {
                 "key": "wrong"
             }
 
-            expect(() => getSubState(() => state, state => state.missing)())
+            let rootState = state
+
+            expect(() => getSubState(() => state, () => rootState, state => state.missing)())
                 .to.throw('mapState must not return undefined.')
         })
 
@@ -137,7 +149,9 @@ describe('subState Tests', () => {
                     "key": "wrong"
                 }
 
-                let subState = getSubState(() => state, state => state.missing)()
+                let rootState = state
+
+                let subState = getSubState(() => state, () => rootState, state => state.missing)()
 
                 expect(subState).to.be.undefined
             } finally {


### PR DESCRIPTION
Currently, if `mapState` does not return an object (e.g. `boolean`, `number`, `array`, etc.) the `root` node is no added to the sub-state.  When this occurs, the second parameter of `mapState` (`rootState`) will not  populate.

This change moves to onus of maintaining the root of the store from the sub-state to the sub-store itself.

---
I have improved the display name of the HOC component.  Instead of `SubspacedComponent` it will now include the name of the component that is subspaced, i.e. `Subspaced(MyComponent)`.

---
I have added `react-redux` as a peer dependency.  Although we don't use it directly, we expect the store to be provided by a `Provider` so this should give a pre-warning if they aren't using it at all.

---
There are some npm badges included in the README.