### PR TITLE
Add Counter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm install --save redux-subspace
 * [Introduction](/docs/Introduction.md)
 * [Basics](/docs/basics/README.md)
 * [Advanced](/docs/advanced/README.md)
+* [Examples](/docs/Examples.md)
 * [API Reference](/docs/api/README.md)
 
 ## Sub-Packages

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,0 +1,5 @@
+# Examples
+
+Redux Subspace is distributed with a few examples in its [source code](/examples). Most of these examples are also on [CodeSandbox](https://codesandbox.io/), this is an online editor that lets you play with the examples online.
+
+* [Counter](/examples/counter)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
     * [redux-thunk](/docs/advanced/middleware/redux-thunk.md)
     * [redux-saga](/docs/advanced/middleware/redux-saga.md)
     * [Custom Middleware](/docs/advanced/middleware/CustomMiddleware.md)
+* [Examples](/docs/Examples.md)
 * [API Reference](/docs/api/README.md)
   * [subspace](/docs/api/subspace.md)
   * [applyMiddleware](/docs/api/applyMiddleware.md)

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,0 +1,15 @@
+# Counter
+
+This example extends [Redux's counter example](https://github.com/reactjs/redux/tree/master/examples/counter) to have multiple counters on the same page.
+
+To run the example locally:
+
+```sh
+git clone https://github.com/ioof-holdings/redux-subspace.git
+
+cd redux-subspace/examples/counter
+npm install
+npm start
+```
+
+Or check out the [sandbox](https://codesandbox.io/s/github/ioof-holdings/redux-subspace/tree/master/examples/counter).

--- a/examples/counter/package-lock.json
+++ b/examples/counter/package-lock.json
@@ -1,0 +1,9894 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"abab": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+			"integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
+		},
+		"accepts": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+			"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+			"requires": {
+				"mime-types": "2.1.16",
+				"negotiator": "0.6.1"
+			}
+		},
+		"acorn": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+		},
+		"acorn-dynamic-import": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+			"requires": {
+				"acorn": "4.0.13"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				}
+			}
+		},
+		"acorn-globals": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"requires": {
+				"acorn": "4.0.13"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				}
+			}
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+				}
+			}
+		},
+		"address": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.0.2.tgz",
+			"integrity": "sha1-SACB6CtYe6MZRZ/vUS9Rb+A9WK8="
+		},
+		"ajv": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+			"integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.0.0",
+				"json-schema-traverse": "0.3.1",
+				"json-stable-stringify": "1.0.1"
+			}
+		},
+		"ajv-keywords": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"alphanum-sort": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+		},
+		"anser": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/anser/-/anser-1.4.1.tgz",
+			"integrity": "sha1-w2QYY6lizr75Qeoshwbyy08HFr0="
+		},
+		"ansi-align": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+			"integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+			"requires": {
+				"string-width": "1.0.2"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"ansi-escapes": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+			"integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
+		},
+		"ansi-html": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+			"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+			"requires": {
+				"color-convert": "1.9.0"
+			}
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"requires": {
+				"default-require-extensions": "1.0.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"aria-query": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.0.tgz",
+			"integrity": "sha512-/r2lHl09V3o74+2MLKEdewoj37YZqiQZnfen1O4iNlrOjUgeKuu1U2yF3iKh6HJxqF+OXkLMfQv65Z/cvxD6vA==",
+			"requires": {
+				"ast-types-flow": "0.0.7"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"array-flatten": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+		},
+		"array-includes": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.8.0"
+			}
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"asn1.js": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"assert": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"requires": {
+				"util": "0.10.3"
+			}
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+		},
+		"ast-types-flow": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+		},
+		"async": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"autoprefixer": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.2.tgz",
+			"integrity": "sha1-++rwfUj9h44Ggr98vurecorbKxg=",
+			"requires": {
+				"browserslist": "2.3.3",
+				"caniuse-lite": "1.0.30000715",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "6.0.9",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"axobject-query": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
+			"integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+			"requires": {
+				"ast-types-flow": "0.0.7"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"babel-core": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+			"requires": {
+				"babel-code-frame": "6.22.0",
+				"babel-generator": "6.25.0",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4",
+				"convert-source-map": "1.5.0",
+				"debug": "2.6.8",
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.7",
+				"slash": "1.0.0",
+				"source-map": "0.5.6"
+			}
+		},
+		"babel-eslint": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+			"integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+			"requires": {
+				"babel-code-frame": "6.22.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4"
+			}
+		},
+		"babel-generator": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.4",
+				"source-map": "0.5.6",
+				"trim-right": "1.0.1"
+			}
+		},
+		"babel-helper-builder-binary-assignment-operator-visitor": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"requires": {
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-builder-react-jsx": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
+			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0",
+				"esutils": "2.0.2"
+			}
+		},
+		"babel-helper-call-delegate": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-define-map": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-helper-explode-assignable-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"requires": {
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-get-function-arity": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-hoist-variables": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-optimise-call-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-helper-remap-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helper-replace-supers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"requires": {
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0"
+			}
+		},
+		"babel-jest": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
+			"integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+			"requires": {
+				"babel-core": "6.25.0",
+				"babel-plugin-istanbul": "4.1.4",
+				"babel-preset-jest": "20.0.3"
+			}
+		},
+		"babel-loader": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.1.tgz",
+			"integrity": "sha1-uHE0yLEuPkwqlOBUYIW8aAorhIg=",
+			"requires": {
+				"find-cache-dir": "1.0.0",
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-check-es2015-constants": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-dynamic-import-node": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.0.2.tgz",
+			"integrity": "sha1-rbW8j0iokxFUA5WunwzD7UsQuy4=",
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0",
+				"babel-template": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
+			"integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+			"requires": {
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.7.4",
+				"test-exclude": "4.1.1"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
+			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
+		},
+		"babel-plugin-syntax-async-functions": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+		},
+		"babel-plugin-syntax-class-properties": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+		},
+		"babel-plugin-syntax-exponentiation-operator": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+		},
+		"babel-plugin-syntax-flow": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+		},
+		"babel-plugin-syntax-jsx": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+		},
+		"babel-plugin-syntax-trailing-function-commas": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+		},
+		"babel-plugin-transform-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-class-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-arrow-functions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-block-scoped-functions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-block-scoping": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-plugin-transform-es2015-classes": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"requires": {
+				"babel-helper-define-map": "6.24.1",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-computed-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-destructuring": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-duplicate-keys": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-for-of": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-amd": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"requires": {
+				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-commonjs": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+			"requires": {
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-systemjs": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-umd": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"requires": {
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-object-super": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"requires": {
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-parameters": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"requires": {
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-shorthand-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-spread": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-sticky-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"requires": {
+				"babel-helper-regex": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-plugin-transform-es2015-template-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-typeof-symbol": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-es2015-unicode-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"requires": {
+				"babel-helper-regex": "6.24.1",
+				"babel-runtime": "6.23.0",
+				"regexpu-core": "2.0.0"
+			}
+		},
+		"babel-plugin-transform-exponentiation-operator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"requires": {
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-flow-strip-types": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"requires": {
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-object-rest-spread": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
+			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+			"requires": {
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-react-constant-elements": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz",
+			"integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-react-display-name": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-react-jsx": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"requires": {
+				"babel-helper-builder-react-jsx": "6.24.1",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-react-jsx-self": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"requires": {
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-react-jsx-source": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"requires": {
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-regenerator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+			"requires": {
+				"regenerator-transform": "0.9.11"
+			}
+		},
+		"babel-plugin-transform-runtime": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+			"requires": {
+				"babel-runtime": "6.23.0"
+			}
+		},
+		"babel-plugin-transform-strict-mode": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0"
+			}
+		},
+		"babel-preset-env": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
+			"integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8=",
+			"requires": {
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.24.1",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.24.1",
+				"browserslist": "2.3.3",
+				"invariant": "2.2.2",
+				"semver": "5.4.1"
+			}
+		},
+		"babel-preset-flow": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"requires": {
+				"babel-plugin-transform-flow-strip-types": "6.22.0"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
+			"integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+			"requires": {
+				"babel-plugin-jest-hoist": "20.0.3"
+			}
+		},
+		"babel-preset-react": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"requires": {
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-self": "6.22.0",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-preset-flow": "6.23.0"
+			}
+		},
+		"babel-preset-react-app": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.0.2.tgz",
+			"integrity": "sha512-UwRU1ppOl1JQEXnCXy8aFsKtvSkn1pNQULveOGZsytfrlHUYu9gU+D+zPYY6yMcAtbvQ4hFs+uA0bpPNwR9++Q==",
+			"requires": {
+				"babel-plugin-dynamic-import-node": "1.0.2",
+				"babel-plugin-syntax-dynamic-import": "6.18.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-object-rest-spread": "6.23.0",
+				"babel-plugin-transform-react-constant-elements": "6.23.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-self": "6.22.0",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-plugin-transform-regenerator": "6.24.1",
+				"babel-plugin-transform-runtime": "6.23.0",
+				"babel-preset-env": "1.5.2",
+				"babel-preset-react": "6.24.1"
+			}
+		},
+		"babel-register": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+			"requires": {
+				"babel-core": "6.25.0",
+				"babel-runtime": "6.23.0",
+				"core-js": "2.5.0",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.15"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+					"integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+			"integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+			"requires": {
+				"core-js": "2.5.0",
+				"regenerator-runtime": "0.10.5"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+					"integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+				}
+			}
+		},
+		"babel-template": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+			"requires": {
+				"babel-code-frame": "6.22.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4",
+				"debug": "2.6.8",
+				"globals": "9.18.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-types": {
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.17.4",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base64-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+		},
+		"batch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"big.js": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+			"integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
+		},
+		"binary-extensions": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+			"integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+		},
+		"bluebird": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+			"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+		},
+		"bn.js": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+		},
+		"bonjour": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+			"requires": {
+				"array-flatten": "2.1.1",
+				"deep-equal": "1.0.1",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.1.1",
+				"multicast-dns-service-types": "1.1.0"
+			}
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"boxen": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+			"integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+			"requires": {
+				"ansi-align": "1.1.0",
+				"camelcase": "2.1.1",
+				"chalk": "1.1.3",
+				"cli-boxes": "1.0.0",
+				"filled-array": "1.1.0",
+				"object-assign": "4.1.1",
+				"repeating": "2.0.1",
+				"string-width": "1.0.2",
+				"widest-line": "1.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"browser-resolve": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+				}
+			}
+		},
+		"browserify-aes": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+			"integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
+			"requires": {
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.0",
+				"inherits": "2.0.3"
+			}
+		},
+		"browserify-cipher": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"requires": {
+				"browserify-aes": "1.0.6",
+				"browserify-des": "1.0.0",
+				"evp_bytestokey": "1.0.0"
+			}
+		},
+		"browserify-des": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.5"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"elliptic": "6.4.0",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.0"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"requires": {
+				"pako": "0.2.9"
+			}
+		},
+		"browserslist": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.3.tgz",
+			"integrity": "sha512-p9hz6FA2H1w1ZUAXKfK3MlIA4Z9fEd56hnZSOecBIITb5j0oZk/tZRwhdE0xG56RGx2x8cc1c5AWJKWVjMLOEQ==",
+			"requires": {
+				"caniuse-lite": "1.0.30000715",
+				"electron-to-chromium": "1.3.18"
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"requires": {
+				"node-int64": "0.4.0"
+			}
+		},
+		"buffer": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+			"requires": {
+				"base64-js": "1.2.1",
+				"ieee754": "1.1.8",
+				"isarray": "1.0.0"
+			}
+		},
+		"buffer-indexof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz",
+			"integrity": "sha1-9U9kfE9OJSKLqmVqLlfkPV8nCYI="
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"builtin-status-codes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+		},
+		"bytes": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
+			"integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"requires": {
+				"callsites": "0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+		},
+		"camel-case": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"requires": {
+				"no-case": "2.3.1",
+				"upper-case": "1.1.3"
+			}
+		},
+		"camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"requires": {
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+				}
+			}
+		},
+		"caniuse-api": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000715",
+				"lodash.memoize": "4.1.2",
+				"lodash.uniq": "4.5.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "1.7.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+					"requires": {
+						"caniuse-db": "1.0.30000715",
+						"electron-to-chromium": "1.3.18"
+					}
+				}
+			}
+		},
+		"caniuse-db": {
+			"version": "1.0.30000715",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+			"integrity": "sha1-C5tceVlQ37rzAaiAa6/ofxJtqMo="
+		},
+		"caniuse-lite": {
+			"version": "1.0.30000715",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
+			"integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA="
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+		},
+		"case-sensitive-paths-webpack-plugin": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz",
+			"integrity": "sha1-PSnO2MHxJL9vU4Rvs/WJRzH9yQk="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"chokidar": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"requires": {
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.1.2",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
+			}
+		},
+		"ci-info": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ="
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+		},
+		"clap": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+			"integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
+			"requires": {
+				"chalk": "1.1.3"
+			}
+		},
+		"clean-css": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.7.tgz",
+			"integrity": "sha1-ua6k+FZ5iJzz6ui0A0nsTr390DI=",
+			"requires": {
+				"source-map": "0.5.6"
+			}
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+			"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"coa": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+			"requires": {
+				"q": "1.5.0"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"color": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+			"requires": {
+				"clone": "1.0.2",
+				"color-convert": "1.9.0",
+				"color-string": "0.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-string": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"colormin": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+			"requires": {
+				"color": "0.11.4",
+				"css-color-names": "0.0.4",
+				"has": "1.0.1"
+			}
+		},
+		"colors": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+		},
+		"combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"compressible": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
+			"integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
+			"requires": {
+				"mime-db": "1.29.0"
+			}
+		},
+		"compression": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
+			"integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
+			"requires": {
+				"accepts": "1.3.3",
+				"bytes": "2.5.0",
+				"compressible": "2.0.11",
+				"debug": "2.6.8",
+				"on-headers": "1.0.1",
+				"safe-buffer": "5.1.1",
+				"vary": "1.1.1"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
+			}
+		},
+		"configstore": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+			"integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+			"requires": {
+				"dot-prop": "3.0.0",
+				"graceful-fs": "4.1.11",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"os-tmpdir": "1.0.2",
+				"osenv": "0.1.4",
+				"uuid": "2.0.3",
+				"write-file-atomic": "1.3.4",
+				"xdg-basedir": "2.0.0"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+				}
+			}
+		},
+		"connect-history-api-fallback": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+			"integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk="
+		},
+		"console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"requires": {
+				"date-now": "0.1.4"
+			}
+		},
+		"constants-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+			"integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+		},
+		"content-type-parser": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
+		},
+		"convert-source-map": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cosmiconfig": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+			"requires": {
+				"is-directory": "0.3.1",
+				"js-yaml": "3.7.0",
+				"minimist": "1.2.0",
+				"object-assign": "4.1.1",
+				"os-homedir": "1.0.2",
+				"parse-json": "2.2.0",
+				"require-from-string": "1.2.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"create-ecdh": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.0"
+			}
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"requires": {
+				"capture-stack-trace": "1.0.0"
+			}
+		},
+		"create-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"sha.js": "2.4.8"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.8"
+			}
+		},
+		"create-react-class": {
+			"version": "15.6.0",
+			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+			"integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+			"requires": {
+				"fbjs": "0.8.14",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"requires": {
+				"boom": "2.10.1"
+			}
+		},
+		"crypto-browserify": {
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+			"requires": {
+				"browserify-cipher": "1.0.0",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.0",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"diffie-hellman": "5.0.2",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.13",
+				"public-encrypt": "4.0.0",
+				"randombytes": "2.0.5"
+			}
+		},
+		"css-color-names": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+		},
+		"css-loader": {
+			"version": "0.28.4",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.4.tgz",
+			"integrity": "sha1-bPNXkZLONV6LONX0Ldeh8uyJjQ8=",
+			"requires": {
+				"babel-code-frame": "6.22.0",
+				"css-selector-tokenizer": "0.7.0",
+				"cssnano": "3.10.0",
+				"icss-utils": "2.1.0",
+				"loader-utils": "1.1.0",
+				"lodash.camelcase": "4.3.0",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.17",
+				"postcss-modules-extract-imports": "1.1.0",
+				"postcss-modules-local-by-default": "1.2.0",
+				"postcss-modules-scope": "1.1.0",
+				"postcss-modules-values": "1.3.0",
+				"postcss-value-parser": "3.3.0",
+				"source-list-map": "0.1.8"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"css-select": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"requires": {
+				"boolbase": "1.0.0",
+				"css-what": "2.1.0",
+				"domutils": "1.5.1",
+				"nth-check": "1.0.1"
+			}
+		},
+		"css-selector-tokenizer": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+			"requires": {
+				"cssesc": "0.1.0",
+				"fastparse": "1.1.1",
+				"regexpu-core": "1.0.0"
+			},
+			"dependencies": {
+				"regexpu-core": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+					"requires": {
+						"regenerate": "1.3.2",
+						"regjsgen": "0.2.0",
+						"regjsparser": "0.1.5"
+					}
+				}
+			}
+		},
+		"css-what": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+		},
+		"cssesc": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+		},
+		"cssnano": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+			"requires": {
+				"autoprefixer": "6.7.7",
+				"decamelize": "1.2.0",
+				"defined": "1.0.0",
+				"has": "1.0.1",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.17",
+				"postcss-calc": "5.3.1",
+				"postcss-colormin": "2.2.2",
+				"postcss-convert-values": "2.6.1",
+				"postcss-discard-comments": "2.0.4",
+				"postcss-discard-duplicates": "2.1.0",
+				"postcss-discard-empty": "2.1.0",
+				"postcss-discard-overridden": "0.1.1",
+				"postcss-discard-unused": "2.2.3",
+				"postcss-filter-plugins": "2.0.2",
+				"postcss-merge-idents": "2.1.7",
+				"postcss-merge-longhand": "2.0.2",
+				"postcss-merge-rules": "2.1.2",
+				"postcss-minify-font-values": "1.0.5",
+				"postcss-minify-gradients": "1.0.5",
+				"postcss-minify-params": "1.2.2",
+				"postcss-minify-selectors": "2.1.1",
+				"postcss-normalize-charset": "1.1.1",
+				"postcss-normalize-url": "3.0.8",
+				"postcss-ordered-values": "2.2.3",
+				"postcss-reduce-idents": "2.4.0",
+				"postcss-reduce-initial": "1.0.1",
+				"postcss-reduce-transforms": "1.0.4",
+				"postcss-svgo": "2.1.6",
+				"postcss-unique-selectors": "2.0.2",
+				"postcss-value-parser": "3.3.0",
+				"postcss-zindex": "2.2.0"
+			},
+			"dependencies": {
+				"autoprefixer": {
+					"version": "6.7.7",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+					"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+					"requires": {
+						"browserslist": "1.7.7",
+						"caniuse-db": "1.0.30000715",
+						"normalize-range": "0.1.2",
+						"num2fraction": "1.2.2",
+						"postcss": "5.2.17",
+						"postcss-value-parser": "3.3.0"
+					}
+				},
+				"browserslist": {
+					"version": "1.7.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+					"requires": {
+						"caniuse-db": "1.0.30000715",
+						"electron-to-chromium": "1.3.18"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"csso": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+			"requires": {
+				"clap": "1.2.0",
+				"source-map": "0.5.6"
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"requires": {
+				"array-find-index": "1.0.2"
+			}
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"requires": {
+				"es5-ext": "0.10.27"
+			}
+		},
+		"damerau-levenshtein": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+			"integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ="
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+		},
+		"debug": {
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"requires": {
+				"strip-bom": "2.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+		},
+		"del": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"requires": {
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.1"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"depd": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+			"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+		},
+		"des.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"detect-node": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+		},
+		"detect-port-alt": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.3.tgz",
+			"integrity": "sha1-pNLwYddXoDTs83xRQmCph1DysTE=",
+			"requires": {
+				"address": "1.0.2",
+				"debug": "2.6.8"
+			}
+		},
+		"diff": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
+			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg=="
+		},
+		"diffie-hellman": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.0",
+				"randombytes": "2.0.5"
+			}
+		},
+		"dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+		},
+		"dns-packet": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.1.tgz",
+			"integrity": "sha512-eisukPHpsFmhEIDnm2mECIiT0huapmdkC0AH1Lvt613Kz2v1kwolrkecvguFazrqnpxvgYdtcMFTsmQzAeRXZQ==",
+			"requires": {
+				"ip": "1.1.5",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"dns-txt": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+			"requires": {
+				"buffer-indexof": "1.1.0"
+			}
+		},
+		"doctrine": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+			"requires": {
+				"esutils": "2.0.2",
+				"isarray": "1.0.0"
+			}
+		},
+		"dom-converter": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
+			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
+			"requires": {
+				"utila": "0.3.3"
+			},
+			"dependencies": {
+				"utila": {
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
+				}
+			}
+		},
+		"dom-serializer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"requires": {
+				"domelementtype": "1.1.3",
+				"entities": "1.1.1"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+				}
+			}
+		},
+		"dom-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+			"integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
+			"requires": {
+				"urijs": "1.18.12"
+			}
+		},
+		"domain-browser": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+		},
+		"domelementtype": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+		},
+		"domhandler": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+			"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+			"requires": {
+				"domelementtype": "1.3.0"
+			}
+		},
+		"domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"requires": {
+				"dom-serializer": "0.1.0",
+				"domelementtype": "1.3.0"
+			}
+		},
+		"dot-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"dotenv": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+			"integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"electron-to-chromium": {
+			"version": "1.3.18",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+			"integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw="
+		},
+		"elliptic": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.3",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
+		},
+		"emoji-regex": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
+		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+		},
+		"encodeurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+			"integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.18"
+			}
+		},
+		"enhanced-resolve": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
+			}
+		},
+		"entities": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+		},
+		"errno": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"requires": {
+				"prr": "0.0.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.0.tgz",
+			"integrity": "sha512-Cf9/h5MrXtExM20gSS55YFrGKCyPrRBjIVBtVyy8vmlsDfe0NPKMWj65tPLgzyfPuapWxh5whpXCtW4+AW5mRg==",
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.0",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.27",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
+			"integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
+			"requires": {
+				"es6-iterator": "2.0.1",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.27",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.27",
+				"es6-iterator": "2.0.1",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-promise": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+			"integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.27",
+				"es6-iterator": "2.0.1",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.27"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.27",
+				"es6-iterator": "2.0.1",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"requires": {
+				"esprima": "2.7.3",
+				"estraverse": "1.9.3",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+				},
+				"source-map": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"optional": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"escope": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"requires": {
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+			"integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+			"requires": {
+				"ajv": "5.2.2",
+				"babel-code-frame": "6.22.0",
+				"chalk": "1.1.3",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "2.6.8",
+				"doctrine": "2.0.0",
+				"eslint-scope": "3.7.1",
+				"espree": "3.5.0",
+				"esquery": "1.0.0",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "9.18.0",
+				"ignore": "3.3.3",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.2.1",
+				"is-resolvable": "1.0.0",
+				"js-yaml": "3.9.1",
+				"json-stable-stringify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "4.0.0",
+				"progress": "2.0.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.4.1",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.1",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				},
+				"js-yaml": {
+					"version": "3.9.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+					"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+					"requires": {
+						"argparse": "1.0.9",
+						"esprima": "4.0.0"
+					}
+				}
+			}
+		},
+		"eslint-config-react-app": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-2.0.0.tgz",
+			"integrity": "sha512-QzFaZIFfGedhzRI6l2ZkpP99GyEqkcPSPMnGeHt/hWtjtw1QMA1ESQiItBLSUdw+2ZvNqzmFGJDqGI/duo0l+Q=="
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+			"integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+			"requires": {
+				"debug": "2.6.8",
+				"resolve": "1.4.0"
+			}
+		},
+		"eslint-loader": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.9.0.tgz",
+			"integrity": "sha512-40aN976qSNPyb9ejTqjEthZITpls1SVKtwguahmH1dzGCwQU/vySE+xX33VZmD8csU0ahVNCtFlsPgKqRBiqgg==",
+			"requires": {
+				"loader-fs-cache": "1.0.1",
+				"loader-utils": "1.1.0",
+				"object-assign": "4.1.1",
+				"object-hash": "1.1.8",
+				"rimraf": "2.6.1"
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+			"integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+			"requires": {
+				"debug": "2.6.8",
+				"pkg-dir": "1.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"requires": {
+						"find-up": "1.1.2"
+					}
+				}
+			}
+		},
+		"eslint-plugin-flowtype": {
+			"version": "2.35.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.0.tgz",
+			"integrity": "sha512-zjXGjOsHds8b84C0Ad3VViKh+sUA9PeXKHwPRlSLwwSX0v1iUJf/6IX7wxc+w2T2tnDH8PT6B/YgtcEuNI3ssA==",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+			"integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
+			"requires": {
+				"builtin-modules": "1.1.1",
+				"contains-path": "0.1.0",
+				"debug": "2.6.8",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "0.3.1",
+				"eslint-module-utils": "2.1.1",
+				"has": "1.0.1",
+				"lodash.cond": "4.5.2",
+				"minimatch": "3.0.4",
+				"read-pkg-up": "2.0.0"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"requires": {
+						"esutils": "2.0.2",
+						"isarray": "1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				}
+			}
+		},
+		"eslint-plugin-jsx-a11y": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz",
+			"integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
+			"requires": {
+				"aria-query": "0.7.0",
+				"array-includes": "3.0.3",
+				"ast-types-flow": "0.0.7",
+				"axobject-query": "0.1.0",
+				"damerau-levenshtein": "1.0.4",
+				"emoji-regex": "6.5.1",
+				"jsx-ast-utils": "1.4.1"
+			}
+		},
+		"eslint-plugin-react": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz",
+			"integrity": "sha1-J3cKzzn1/UnNCvQIPOWBBOs5DUw=",
+			"requires": {
+				"doctrine": "2.0.0",
+				"has": "1.0.1",
+				"jsx-ast-utils": "1.4.1"
+			}
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"requires": {
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"espree": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+			"integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+			"requires": {
+				"acorn": "5.1.1",
+				"acorn-jsx": "3.0.1"
+			}
+		},
+		"esprima": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+		},
+		"esquery": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"etag": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+			"integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.27"
+			}
+		},
+		"eventemitter3": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+			"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+		},
+		"eventsource": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+			"requires": {
+				"original": "1.0.0"
+			}
+		},
+		"evp_bytestokey": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+			"integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
+			"requires": {
+				"create-hash": "1.1.3"
+			}
+		},
+		"exec-sh": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
+			"integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+			"requires": {
+				"merge": "1.2.0"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"expand-tilde": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"requires": {
+				"homedir-polyfill": "1.0.1"
+			}
+		},
+		"express": {
+			"version": "4.15.4",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
+			"integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+			"requires": {
+				"accepts": "1.3.3",
+				"array-flatten": "1.1.1",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.2",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.8",
+				"depd": "1.1.1",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.0",
+				"finalhandler": "1.0.4",
+				"fresh": "0.5.0",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.1",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "1.1.5",
+				"qs": "6.5.0",
+				"range-parser": "1.2.0",
+				"send": "0.15.4",
+				"serve-static": "1.12.4",
+				"setprototypeof": "1.0.3",
+				"statuses": "1.3.1",
+				"type-is": "1.6.15",
+				"utils-merge": "1.0.0",
+				"vary": "1.1.1"
+			},
+			"dependencies": {
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"path-to-regexp": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+				},
+				"qs": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+					"integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+				}
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"external-editor": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
+			"integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+			"requires": {
+				"iconv-lite": "0.4.18",
+				"jschardet": "1.5.1",
+				"tmp": "0.0.31"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"extract-text-webpack-plugin": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.0.tgz",
+			"integrity": "sha1-kMqnkHvESfM1AF46x1MrQbAN5hI=",
+			"requires": {
+				"async": "2.5.0",
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0",
+				"webpack-sources": "1.0.1"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fastparse": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+		},
+		"faye-websocket": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+			"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+			"requires": {
+				"websocket-driver": "0.6.5"
+			}
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"requires": {
+				"bser": "2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.14",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+			"integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.14"
+			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"requires": {
+				"flat-cache": "1.2.2",
+				"object-assign": "4.1.1"
+			}
+		},
+		"file-loader": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
+			"integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
+			"requires": {
+				"loader-utils": "1.1.0"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"requires": {
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
+			}
+		},
+		"filesize": {
+			"version": "3.5.10",
+			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz",
+			"integrity": "sha1-/I+iPdtO+eXgq24eZPZ5okpWdh8="
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"filled-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+			"integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
+		},
+		"finalhandler": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
+			"integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+			"requires": {
+				"debug": "2.6.8",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.1",
+				"statuses": "1.3.1",
+				"unpipe": "1.0.0"
+			}
+		},
+		"find-cache-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"requires": {
+				"commondir": "1.0.1",
+				"make-dir": "1.0.0",
+				"pkg-dir": "2.0.0"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"flat-cache": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+			"integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+			"requires": {
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
+			}
+		},
+		"flatten": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.16"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+			"integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+		},
+		"fresh": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+			"integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+		},
+		"fs-extra": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+			"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "3.0.1",
+				"universalify": "0.1.1"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"optional": true,
+			"requires": {
+				"nan": "2.6.2",
+				"node-pre-gyp": "0.6.36"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.36",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"requires": {
+				"is-glob": "2.0.1"
+			}
+		},
+		"global-modules": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"requires": {
+				"global-prefix": "1.0.2",
+				"is-windows": "1.0.1",
+				"resolve-dir": "1.0.1"
+			}
+		},
+		"global-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"requires": {
+				"expand-tilde": "2.0.2",
+				"homedir-polyfill": "1.0.1",
+				"ini": "1.3.4",
+				"is-windows": "1.0.1",
+				"which": "1.3.0"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+		},
+		"globby": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"requires": {
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"got": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+			"integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+			"requires": {
+				"create-error-class": "3.0.2",
+				"duplexer2": "0.1.4",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.0",
+				"node-status-codes": "1.0.0",
+				"object-assign": "4.1.1",
+				"parse-json": "2.2.0",
+				"pinkie-promise": "2.0.1",
+				"read-all-stream": "3.1.0",
+				"readable-stream": "2.3.3",
+				"timed-out": "3.1.3",
+				"unzip-response": "1.0.2",
+				"url-parse-lax": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+		},
+		"gzip-size": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+			"integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+			"requires": {
+				"duplexer": "0.1.1"
+			}
+		},
+		"handle-thing": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+		},
+		"handlebars": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"optional": true,
+					"requires": {
+						"source-map": "0.5.6",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.6",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+							"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+							"optional": true
+						}
+					}
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"optional": true,
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"har-schema": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+		},
+		"har-validator": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+			"requires": {
+				"ajv": "4.11.8",
+				"har-schema": "1.0.5"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				}
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"requires": {
+				"function-bind": "1.1.0"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+		},
+		"hash-base": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"requires": {
+				"boom": "2.10.1",
+				"cryptiles": "2.0.5",
+				"hoek": "2.16.3",
+				"sntp": "1.0.9"
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "1.1.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
+		},
+		"hoek": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"homedir-polyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"requires": {
+				"parse-passwd": "1.0.0"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+		},
+		"hpack.js": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"requires": {
+				"inherits": "2.0.3",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.3",
+				"wbuf": "1.7.2"
+			}
+		},
+		"html-comment-regex": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+			"integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+			"requires": {
+				"whatwg-encoding": "1.0.1"
+			}
+		},
+		"html-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+		},
+		"html-minifier": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.3.tgz",
+			"integrity": "sha512-iKRzQQDuTCsq0Ultbi/mfJJnR0D3AdZKTq966Gsp92xkmAPCV4Xi08qhJ0Dl3ZAWemSgJ7qZK+UsZc0gFqK6wg==",
+			"requires": {
+				"camel-case": "3.0.0",
+				"clean-css": "4.1.7",
+				"commander": "2.11.0",
+				"he": "1.1.1",
+				"ncname": "1.0.0",
+				"param-case": "2.1.1",
+				"relateurl": "0.2.7",
+				"uglify-js": "3.0.27"
+			}
+		},
+		"html-webpack-plugin": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz",
+			"integrity": "sha1-6Yf0IYU9O2k4yMTIFxhC5f0XryM=",
+			"requires": {
+				"bluebird": "3.5.0",
+				"html-minifier": "3.5.3",
+				"loader-utils": "0.2.17",
+				"lodash": "4.17.4",
+				"pretty-error": "2.1.1",
+				"toposort": "1.0.3"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"requires": {
+						"big.js": "3.1.3",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
+					}
+				}
+			}
+		},
+		"htmlparser2": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+			"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+			"requires": {
+				"domelementtype": "1.3.0",
+				"domhandler": "2.1.0",
+				"domutils": "1.1.6",
+				"readable-stream": "1.0.34"
+			},
+			"dependencies": {
+				"domutils": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+					"requires": {
+						"domelementtype": "1.3.0"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"http-deceiver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+		},
+		"http-errors": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+			"requires": {
+				"depd": "1.1.1",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.0.3",
+				"statuses": "1.3.1"
+			}
+		},
+		"http-proxy": {
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+			"requires": {
+				"eventemitter3": "1.2.0",
+				"requires-port": "1.0.0"
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+			"requires": {
+				"http-proxy": "1.16.2",
+				"is-glob": "3.1.0",
+				"lodash": "4.17.4",
+				"micromatch": "2.3.11"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				}
+			}
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"requires": {
+				"assert-plus": "0.2.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"https-browserify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+		},
+		"iconv-lite": {
+			"version": "0.4.18",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+			"integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+		},
+		"icss-replace-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+		},
+		"icss-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+			"requires": {
+				"postcss": "6.0.9"
+			}
+		},
+		"ieee754": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+		},
+		"ignore": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0="
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indent-string": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"indexes-of": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+		},
+		"inquirer": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+			"integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+			"requires": {
+				"ansi-escapes": "2.0.0",
+				"chalk": "2.1.0",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.1.0",
+				"external-editor": "2.0.4",
+				"figures": "2.0.0",
+				"lodash": "4.17.4",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"chalk": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.2.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"internal-ip": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+			"requires": {
+				"meow": "3.7.0"
+			}
+		},
+		"interpret": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+		},
+		"invariant": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"ip": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+		},
+		"ipaddr.js": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+			"integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+		},
+		"is-absolute-url": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"requires": {
+				"binary-extensions": "1.10.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+		},
+		"is-ci": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+			"requires": {
+				"ci-info": "1.0.0"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-directory": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"requires": {
+				"is-path-inside": "1.0.0"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "1.0.1"
+			}
+		},
+		"is-resolvable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+			"requires": {
+				"tryit": "1.0.3"
+			}
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+		},
+		"is-root": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+			"integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-svg": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+			"requires": {
+				"html-comment-regex": "1.1.1"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+			"integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.2",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-api": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
+			"integrity": "sha1-/MC0YeKzvaceMFFVE4I4doJX2d4=",
+			"requires": {
+				"async": "2.5.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.1.1",
+				"istanbul-lib-hook": "1.0.7",
+				"istanbul-lib-instrument": "1.7.4",
+				"istanbul-lib-report": "1.1.1",
+				"istanbul-lib-source-maps": "1.2.1",
+				"istanbul-reports": "1.1.1",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+		},
+		"istanbul-lib-hook": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+			"integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+			"requires": {
+				"append-transform": "0.4.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+			"integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
+			"requires": {
+				"babel-generator": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4",
+				"istanbul-lib-coverage": "1.1.1",
+				"semver": "5.4.1"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+			"integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+			"requires": {
+				"istanbul-lib-coverage": "1.1.1",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+			"integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+			"requires": {
+				"debug": "2.6.8",
+				"istanbul-lib-coverage": "1.1.1",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.1",
+				"source-map": "0.5.6"
+			}
+		},
+		"istanbul-reports": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+			"integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+			"requires": {
+				"handlebars": "4.0.10"
+			}
+		},
+		"jest": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
+			"integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+			"requires": {
+				"jest-cli": "20.0.4"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+				},
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+				},
+				"jest-cli": {
+					"version": "20.0.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
+					"integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+					"requires": {
+						"ansi-escapes": "1.4.0",
+						"callsites": "2.0.0",
+						"chalk": "1.1.3",
+						"graceful-fs": "4.1.11",
+						"is-ci": "1.0.10",
+						"istanbul-api": "1.1.11",
+						"istanbul-lib-coverage": "1.1.1",
+						"istanbul-lib-instrument": "1.7.4",
+						"istanbul-lib-source-maps": "1.2.1",
+						"jest-changed-files": "20.0.3",
+						"jest-config": "20.0.4",
+						"jest-docblock": "20.0.3",
+						"jest-environment-jsdom": "20.0.3",
+						"jest-haste-map": "20.0.4",
+						"jest-jasmine2": "20.0.4",
+						"jest-message-util": "20.0.3",
+						"jest-regex-util": "20.0.3",
+						"jest-resolve-dependencies": "20.0.3",
+						"jest-runtime": "20.0.4",
+						"jest-snapshot": "20.0.3",
+						"jest-util": "20.0.3",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.1.2",
+						"pify": "2.3.0",
+						"slash": "1.0.0",
+						"string-length": "1.0.1",
+						"throat": "3.2.0",
+						"which": "1.3.0",
+						"worker-farm": "1.5.0",
+						"yargs": "7.1.0"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
+			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
+		},
+		"jest-config": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
+			"integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+			"requires": {
+				"chalk": "1.1.3",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "20.0.3",
+				"jest-environment-node": "20.0.3",
+				"jest-jasmine2": "20.0.4",
+				"jest-matcher-utils": "20.0.3",
+				"jest-regex-util": "20.0.3",
+				"jest-resolve": "20.0.4",
+				"jest-validate": "20.0.3",
+				"pretty-format": "20.0.3"
+			}
+		},
+		"jest-diff": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
+			"integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+			"requires": {
+				"chalk": "1.1.3",
+				"diff": "3.3.0",
+				"jest-matcher-utils": "20.0.3",
+				"pretty-format": "20.0.3"
+			}
+		},
+		"jest-docblock": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+		},
+		"jest-environment-jsdom": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
+			"integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+			"requires": {
+				"jest-mock": "20.0.3",
+				"jest-util": "20.0.3",
+				"jsdom": "9.12.0"
+			}
+		},
+		"jest-environment-node": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
+			"integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+			"requires": {
+				"jest-mock": "20.0.3",
+				"jest-util": "20.0.3"
+			}
+		},
+		"jest-haste-map": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
+			"integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
+			"requires": {
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "20.0.3",
+				"micromatch": "2.3.11",
+				"sane": "1.6.0",
+				"worker-farm": "1.5.0"
+			}
+		},
+		"jest-jasmine2": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
+			"integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+			"requires": {
+				"chalk": "1.1.3",
+				"graceful-fs": "4.1.11",
+				"jest-diff": "20.0.3",
+				"jest-matcher-utils": "20.0.3",
+				"jest-matchers": "20.0.3",
+				"jest-message-util": "20.0.3",
+				"jest-snapshot": "20.0.3",
+				"once": "1.4.0",
+				"p-map": "1.1.1"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
+			"integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+			"requires": {
+				"chalk": "1.1.3",
+				"pretty-format": "20.0.3"
+			}
+		},
+		"jest-matchers": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
+			"integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+			"requires": {
+				"jest-diff": "20.0.3",
+				"jest-matcher-utils": "20.0.3",
+				"jest-message-util": "20.0.3",
+				"jest-regex-util": "20.0.3"
+			}
+		},
+		"jest-message-util": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
+			"integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+			"requires": {
+				"chalk": "1.1.3",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0"
+			}
+		},
+		"jest-mock": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
+			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
+		},
+		"jest-regex-util": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
+			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
+		},
+		"jest-resolve": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
+			"integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+			"requires": {
+				"browser-resolve": "1.11.2",
+				"is-builtin-module": "1.0.0",
+				"resolve": "1.4.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
+			"integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+			"requires": {
+				"jest-regex-util": "20.0.3"
+			}
+		},
+		"jest-runtime": {
+			"version": "20.0.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
+			"integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+			"requires": {
+				"babel-core": "6.25.0",
+				"babel-jest": "20.0.3",
+				"babel-plugin-istanbul": "4.1.4",
+				"chalk": "1.1.3",
+				"convert-source-map": "1.5.0",
+				"graceful-fs": "4.1.11",
+				"jest-config": "20.0.4",
+				"jest-haste-map": "20.0.4",
+				"jest-regex-util": "20.0.3",
+				"jest-resolve": "20.0.4",
+				"jest-util": "20.0.3",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"strip-bom": "3.0.0",
+				"yargs": "7.1.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				}
+			}
+		},
+		"jest-snapshot": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
+			"integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+			"requires": {
+				"chalk": "1.1.3",
+				"jest-diff": "20.0.3",
+				"jest-matcher-utils": "20.0.3",
+				"jest-util": "20.0.3",
+				"natural-compare": "1.4.0",
+				"pretty-format": "20.0.3"
+			}
+		},
+		"jest-util": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
+			"integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+			"requires": {
+				"chalk": "1.1.3",
+				"graceful-fs": "4.1.11",
+				"jest-message-util": "20.0.3",
+				"jest-mock": "20.0.3",
+				"jest-validate": "20.0.3",
+				"leven": "2.1.0",
+				"mkdirp": "0.5.1"
+			}
+		},
+		"jest-validate": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
+			"integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+			"requires": {
+				"chalk": "1.1.3",
+				"jest-matcher-utils": "20.0.3",
+				"leven": "2.1.0",
+				"pretty-format": "20.0.3"
+			}
+		},
+		"js-base64": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+			"integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"js-yaml": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+			"requires": {
+				"argparse": "1.0.9",
+				"esprima": "2.7.3"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jschardet": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+			"integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
+		},
+		"jsdom": {
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"requires": {
+				"abab": "1.0.3",
+				"acorn": "4.0.13",
+				"acorn-globals": "3.1.0",
+				"array-equal": "1.0.0",
+				"content-type-parser": "1.0.1",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"escodegen": "1.8.1",
+				"html-encoding-sniffer": "1.0.1",
+				"nwmatcher": "1.4.1",
+				"parse5": "1.5.1",
+				"request": "2.81.0",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.2",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.1",
+				"whatwg-url": "4.8.0",
+				"xml-name-validator": "2.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				}
+			}
+		},
+		"jsesc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+		},
+		"json-loader": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+		},
+		"jsonfile": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+			"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"jsx-ast-utils": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.5"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"latest-version": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+			"integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+			"requires": {
+				"package-json": "2.4.0"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+		},
+		"lazy-req": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+			"integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"loader-fs-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
+			"integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
+			"requires": {
+				"find-cache-dir": "0.1.1",
+				"mkdirp": "0.5.1"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+					"requires": {
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"requires": {
+						"find-up": "1.1.2"
+					}
+				}
+			}
+		},
+		"loader-runner": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"requires": {
+				"big.js": "3.1.3",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"lodash-es": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"lodash.cond": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+		},
+		"lodash.template": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.templatesettings": "4.1.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+			"requires": {
+				"lodash._reinterpolate": "3.0.0"
+			}
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+		},
+		"loglevel": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
+			"integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80="
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"requires": {
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"lower-case": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+		},
+		"lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"macaddress": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
+		},
+		"make-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+			"integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"requires": {
+				"tmpl": "1.0.4"
+			}
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+		},
+		"math-expression-evaluator": {
+			"version": "1.2.17",
+			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.1.0"
+			}
+		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"requires": {
+				"errno": "0.1.4",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"requires": {
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"merge": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.3"
+			}
+		},
+		"miller-rabin": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+			"integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
+			}
+		},
+		"mime": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+			"integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+		},
+		"mime-db": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+		},
+		"mime-types": {
+			"version": "2.1.16",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+			"requires": {
+				"mime-db": "1.29.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+		},
+		"minimalistic-assert": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.8"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multicast-dns": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
+			"integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+			"requires": {
+				"dns-packet": "1.2.1",
+				"thunky": "0.1.0"
+			}
+		},
+		"multicast-dns-service-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"nan": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+			"integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+			"optional": true
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"ncname": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+			"integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
+			"requires": {
+				"xml-char-classes": "1.0.0"
+			}
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
+		"no-case": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
+			"integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
+			"requires": {
+				"lower-case": "1.1.4"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
+			"integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"node-forge": {
+			"version": "0.6.33",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
+			"integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw="
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+		},
+		"node-libs-browser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"requires": {
+				"assert": "1.4.1",
+				"browserify-zlib": "0.1.4",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.11.1",
+				"domain-browser": "1.1.7",
+				"events": "1.1.1",
+				"https-browserify": "0.0.1",
+				"os-browserify": "0.2.1",
+				"path-browserify": "0.0.0",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.3",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.7.2",
+				"string_decoder": "0.10.31",
+				"timers-browserify": "2.0.4",
+				"tty-browserify": "0.0.0",
+				"url": "0.11.0",
+				"util": "0.10.3",
+				"vm-browserify": "0.0.4"
+			},
+			"dependencies": {
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"node-notifier": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+			"integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+			"requires": {
+				"growly": "1.3.0",
+				"semver": "5.4.1",
+				"shellwords": "0.1.0",
+				"which": "1.3.0"
+			}
+		},
+		"node-status-codes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+			"integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.4.1",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "1.0.2"
+			}
+		},
+		"normalize-range": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+		},
+		"normalize-url": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"prepend-http": "1.0.4",
+				"query-string": "4.3.4",
+				"sort-keys": "1.1.2"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"nth-check": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+			"requires": {
+				"boolbase": "1.0.0"
+			}
+		},
+		"num2fraction": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nwmatcher": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
+			"integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-hash": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
+			"integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw="
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"obuf": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+			"integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"requires": {
+				"mimic-fn": "1.1.0"
+			}
+		},
+		"opn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+			"integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+			"requires": {
+				"is-wsl": "1.1.0"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"requires": {
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+				}
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			}
+		},
+		"original": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+			"requires": {
+				"url-parse": "1.0.5"
+			},
+			"dependencies": {
+				"url-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+					"requires": {
+						"querystringify": "0.0.4",
+						"requires-port": "1.0.0"
+					}
+				}
+			}
+		},
+		"os-browserify": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"requires": {
+				"lcid": "1.0.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"osenv": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+			"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.1.0"
+			}
+		},
+		"p-map": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
+			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
+		},
+		"package-json": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+			"integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+			"requires": {
+				"got": "5.7.1",
+				"registry-auth-token": "3.3.1",
+				"registry-url": "3.1.0",
+				"semver": "5.4.1"
+			}
+		},
+		"pako": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+		},
+		"param-case": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+			"requires": {
+				"no-case": "2.3.1"
+			}
+		},
+		"parse-asn1": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"requires": {
+				"asn1.js": "4.9.1",
+				"browserify-aes": "1.0.6",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.0",
+				"pbkdf2": "3.0.13"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+		},
+		"parse5": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+		},
+		"parseurl": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+			"integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+		},
+		"path-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				}
+			}
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"pbkdf2": {
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+			"integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+			"requires": {
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.8"
+			}
+		},
+		"performance-now": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"requires": {
+				"find-up": "2.1.0"
+			}
+		},
+		"pluralize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+			"integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I="
+		},
+		"portfinder": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+			"requires": {
+				"async": "1.5.2",
+				"debug": "2.6.8",
+				"mkdirp": "0.5.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				}
+			}
+		},
+		"postcss": {
+			"version": "6.0.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
+			"integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
+			"requires": {
+				"chalk": "2.1.0",
+				"source-map": "0.5.6",
+				"supports-color": "4.2.1"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.2.1"
+					}
+				}
+			}
+		},
+		"postcss-calc": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+			"requires": {
+				"postcss": "5.2.17",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-css-calc": "1.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-colormin": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+			"requires": {
+				"colormin": "1.1.2",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-convert-values": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+			"requires": {
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-discard-comments": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+			"requires": {
+				"postcss": "5.2.17"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-discard-duplicates": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+			"requires": {
+				"postcss": "5.2.17"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-discard-empty": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+			"requires": {
+				"postcss": "5.2.17"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-discard-overridden": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+			"requires": {
+				"postcss": "5.2.17"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-discard-unused": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+			"requires": {
+				"postcss": "5.2.17",
+				"uniqs": "2.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-filter-plugins": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+			"requires": {
+				"postcss": "5.2.17",
+				"uniqid": "4.1.1"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-flexbugs-fixes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.2.0.tgz",
+			"integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
+			"requires": {
+				"postcss": "6.0.9"
+			}
+		},
+		"postcss-load-config": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+			"requires": {
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1",
+				"postcss-load-options": "1.2.0",
+				"postcss-load-plugins": "2.3.0"
+			}
+		},
+		"postcss-load-options": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+			"requires": {
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
+			}
+		},
+		"postcss-load-plugins": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+			"requires": {
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
+			}
+		},
+		"postcss-loader": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.6.tgz",
+			"integrity": "sha512-HIq7yy1hh9KI472Y38iSRV4WupZUNy6zObkxQM/ZuInoaE2+PyX4NcO6jjP5HG5mXL7j5kcNEl0fAG4Kva7O9w==",
+			"requires": {
+				"loader-utils": "1.1.0",
+				"postcss": "6.0.9",
+				"postcss-load-config": "1.2.0",
+				"schema-utils": "0.3.0"
+			}
+		},
+		"postcss-merge-idents": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-merge-longhand": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+			"requires": {
+				"postcss": "5.2.17"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-merge-rules": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-api": "1.6.1",
+				"postcss": "5.2.17",
+				"postcss-selector-parser": "2.2.3",
+				"vendors": "1.0.1"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "1.7.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+					"requires": {
+						"caniuse-db": "1.0.30000715",
+						"electron-to-chromium": "1.3.18"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-message-helpers": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
+		},
+		"postcss-minify-font-values": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-minify-gradients": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+			"requires": {
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-minify-params": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0",
+				"uniqs": "2.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-minify-selectors": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"postcss-selector-parser": "2.2.3"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-modules-extract-imports": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+			"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+			"requires": {
+				"postcss": "6.0.9"
+			}
+		},
+		"postcss-modules-local-by-default": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+			"requires": {
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.9"
+			}
+		},
+		"postcss-modules-scope": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+			"requires": {
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.9"
+			}
+		},
+		"postcss-modules-values": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+			"requires": {
+				"icss-replace-symbols": "1.1.0",
+				"postcss": "6.0.9"
+			}
+		},
+		"postcss-normalize-charset": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+			"requires": {
+				"postcss": "5.2.17"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-url": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+			"requires": {
+				"is-absolute-url": "2.1.0",
+				"normalize-url": "1.9.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-ordered-values": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+			"requires": {
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-reduce-idents": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+			"requires": {
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-reduce-initial": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+			"requires": {
+				"postcss": "5.2.17"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-reduce-transforms": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-selector-parser": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+			"requires": {
+				"flatten": "1.0.2",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
+			}
+		},
+		"postcss-svgo": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+			"requires": {
+				"is-svg": "2.1.0",
+				"postcss": "5.2.17",
+				"postcss-value-parser": "3.3.0",
+				"svgo": "0.7.2"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-unique-selectors": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.17",
+				"uniqs": "2.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-value-parser": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+		},
+		"postcss-zindex": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.17",
+				"uniqs": "2.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"postcss": {
+					"version": "5.2.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+					"integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+					"requires": {
+						"chalk": "1.1.3",
+						"js-base64": "2.1.9",
+						"source-map": "0.5.6",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-bytes": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+		},
+		"pretty-error": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+			"requires": {
+				"renderkid": "2.0.1",
+				"utila": "0.4.0"
+			}
+		},
+		"pretty-format": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+			"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+			"requires": {
+				"ansi-regex": "2.1.1",
+				"ansi-styles": "3.2.0"
+			}
+		},
+		"private": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+		},
+		"progress": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.5.10",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+			"requires": {
+				"fbjs": "0.8.14",
+				"loose-envify": "1.3.1"
+			}
+		},
+		"proxy-addr": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+			"integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+			"requires": {
+				"forwarded": "0.1.0",
+				"ipaddr.js": "1.4.0"
+			}
+		},
+		"prr": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"public-encrypt": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"parse-asn1": "5.1.0",
+				"randombytes": "2.0.5"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"q": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+			"integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+		},
+		"qs": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+		},
+		"query-string": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
+			}
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
+		"querystring-es3": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+		},
+		"querystringify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.5"
+					}
+				}
+			}
+		},
+		"randombytes": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"rc": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.4",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"react": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
+			"integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+			"requires": {
+				"create-react-class": "15.6.0",
+				"fbjs": "0.8.14",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.5.10"
+			}
+		},
+		"react-dev-utils": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-3.1.1.tgz",
+			"integrity": "sha512-xuScoO3RqgGrD15WMtmJf2MoHFu/G886lk8z3vvj87Afxm74UdAyDqtxkCBXvyjUXGRo774HQI7NsSoT9oNXQQ==",
+			"requires": {
+				"address": "1.0.2",
+				"anser": "1.4.1",
+				"babel-code-frame": "6.22.0",
+				"chalk": "1.1.3",
+				"cross-spawn": "5.1.0",
+				"detect-port-alt": "1.1.3",
+				"escape-string-regexp": "1.0.5",
+				"filesize": "3.5.10",
+				"global-modules": "1.0.0",
+				"gzip-size": "3.0.0",
+				"html-entities": "1.2.1",
+				"inquirer": "3.2.1",
+				"is-root": "1.0.0",
+				"opn": "5.1.0",
+				"recursive-readdir": "2.2.1",
+				"shell-quote": "1.6.1",
+				"sockjs-client": "1.1.4",
+				"strip-ansi": "3.0.1",
+				"text-table": "0.2.0"
+			}
+		},
+		"react-dom": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
+			"integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+			"requires": {
+				"fbjs": "0.8.14",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.5.10"
+			}
+		},
+		"react-error-overlay": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-1.0.10.tgz",
+			"integrity": "sha512-/fzpqRGPWlpDvvBwLN7vjE4FAI81ajbWowkrycY8P5RGqE49WIUMIdFjTS5htqJfzxcM599k/x1lCayaq+4qEw==",
+			"requires": {
+				"anser": "1.4.1",
+				"babel-code-frame": "6.22.0",
+				"babel-runtime": "6.23.0",
+				"react-dev-utils": "3.1.1",
+				"settle-promise": "1.0.0",
+				"source-map": "0.5.6"
+			}
+		},
+		"react-scripts": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.0.11.tgz",
+			"integrity": "sha512-mUgWK/cJk/36RFadYCeVf3MEvwfrp2DcJmMZs2ujayI4Ggia6QC2oHX3hqLgS17pfcr9SZsVc2rlYNReW3DeFA==",
+			"requires": {
+				"autoprefixer": "7.1.2",
+				"babel-core": "6.25.0",
+				"babel-eslint": "7.2.3",
+				"babel-jest": "20.0.3",
+				"babel-loader": "7.1.1",
+				"babel-preset-react-app": "3.0.2",
+				"babel-runtime": "6.23.0",
+				"case-sensitive-paths-webpack-plugin": "2.1.1",
+				"chalk": "1.1.3",
+				"css-loader": "0.28.4",
+				"dotenv": "4.0.0",
+				"eslint": "4.4.1",
+				"eslint-config-react-app": "2.0.0",
+				"eslint-loader": "1.9.0",
+				"eslint-plugin-flowtype": "2.35.0",
+				"eslint-plugin-import": "2.7.0",
+				"eslint-plugin-jsx-a11y": "5.1.1",
+				"eslint-plugin-react": "7.1.0",
+				"extract-text-webpack-plugin": "3.0.0",
+				"file-loader": "0.11.2",
+				"fs-extra": "3.0.1",
+				"fsevents": "1.1.2",
+				"html-webpack-plugin": "2.29.0",
+				"jest": "20.0.4",
+				"object-assign": "4.1.1",
+				"postcss-flexbugs-fixes": "3.2.0",
+				"postcss-loader": "2.0.6",
+				"promise": "8.0.1",
+				"react-dev-utils": "3.1.1",
+				"react-error-overlay": "1.0.10",
+				"style-loader": "0.18.2",
+				"sw-precache-webpack-plugin": "0.11.4",
+				"url-loader": "0.5.9",
+				"webpack": "3.5.1",
+				"webpack-dev-server": "2.7.1",
+				"webpack-manifest-plugin": "1.2.1",
+				"whatwg-fetch": "2.0.3"
+			},
+			"dependencies": {
+				"promise": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
+					"integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
+					"requires": {
+						"asap": "2.0.6"
+					}
+				}
+			}
+		},
+		"read-all-stream": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+			"integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+			"requires": {
+				"pinkie-promise": "2.0.1",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"requires": {
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.3",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"recursive-readdir": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+			"integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+			"requires": {
+				"minimatch": "3.0.3"
+			},
+			"dependencies": {
+				"minimatch": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				}
+			}
+		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"requires": {
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
+			}
+		},
+		"reduce-css-calc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+			"requires": {
+				"balanced-match": "0.4.2",
+				"math-expression-evaluator": "1.2.17",
+				"reduce-function-call": "1.0.2"
+			},
+			"dependencies": {
+				"balanced-match": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+				}
+			}
+		},
+		"reduce-function-call": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+			"requires": {
+				"balanced-match": "0.4.2"
+			},
+			"dependencies": {
+				"balanced-match": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+				}
+			}
+		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.4",
+				"lodash-es": "4.17.4",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.0.4"
+			}
+		},
+		"regenerate": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+		},
+		"regenerator-runtime": {
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+		},
+		"regenerator-transform": {
+			"version": "0.9.11",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+			"requires": {
+				"babel-runtime": "6.23.0",
+				"babel-types": "6.25.0",
+				"private": "0.1.7"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+			"requires": {
+				"is-equal-shallow": "0.1.3",
+				"is-primitive": "2.0.0"
+			}
+		},
+		"regexpu-core": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"requires": {
+				"regenerate": "1.3.2",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+			"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+			"requires": {
+				"rc": "1.2.1",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"requires": {
+				"rc": "1.2.1"
+			}
+		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"requires": {
+				"jsesc": "0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
+			}
+		},
+		"relateurl": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+		},
+		"remove-trailing-separator": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+		},
+		"renderkid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
+			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
+			"requires": {
+				"css-select": "1.2.0",
+				"dom-converter": "0.1.4",
+				"htmlparser2": "3.3.0",
+				"strip-ansi": "3.0.1",
+				"utila": "0.3.3"
+			},
+			"dependencies": {
+				"utila": {
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
+				}
+			}
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"request": {
+			"version": "2.81.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"requires": {
+				"aws-sign2": "0.6.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.1.4",
+				"har-validator": "4.2.1",
+				"hawk": "3.1.3",
+				"http-signature": "1.1.1",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.16",
+				"oauth-sign": "0.8.2",
+				"performance-now": "0.2.0",
+				"qs": "6.4.0",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.2",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.1.0"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-from-string": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+			"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			}
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
+		"resolve": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+			"requires": {
+				"path-parse": "1.0.5"
+			}
+		},
+		"resolve-dir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+			"requires": {
+				"expand-tilde": "2.0.2",
+				"global-modules": "1.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"requires": {
+				"hash-base": "2.0.2",
+				"inherits": "2.0.3"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"sane": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
+			"integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+			"requires": {
+				"anymatch": "1.3.2",
+				"exec-sh": "0.2.0",
+				"fb-watchman": "1.9.2",
+				"minimatch": "3.0.4",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.10.0"
+			},
+			"dependencies": {
+				"bser": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"requires": {
+						"node-int64": "0.4.0"
+					}
+				},
+				"fb-watchman": {
+					"version": "1.9.2",
+					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
+					"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+					"requires": {
+						"bser": "1.0.2"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"schema-utils": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+			"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+			"requires": {
+				"ajv": "5.2.2"
+			}
+		},
+		"select-hose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+		},
+		"selfsigned": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
+			"integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
+			"requires": {
+				"node-forge": "0.6.33"
+			}
+		},
+		"semver": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"requires": {
+				"semver": "5.4.1"
+			}
+		},
+		"send": {
+			"version": "0.15.4",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+			"integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+			"requires": {
+				"debug": "2.6.8",
+				"depd": "1.1.1",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"etag": "1.8.0",
+				"fresh": "0.5.0",
+				"http-errors": "1.6.2",
+				"mime": "1.3.4",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.3.1"
+			},
+			"dependencies": {
+				"mime": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+					"integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+				}
+			}
+		},
+		"serve-index": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
+			"integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
+			"requires": {
+				"accepts": "1.3.3",
+				"batch": "0.6.1",
+				"debug": "2.6.8",
+				"escape-html": "1.0.3",
+				"http-errors": "1.6.2",
+				"mime-types": "2.1.16",
+				"parseurl": "1.3.1"
+			}
+		},
+		"serve-static": {
+			"version": "1.12.4",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
+			"integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+			"requires": {
+				"encodeurl": "1.0.1",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.1",
+				"send": "0.15.4"
+			}
+		},
+		"serviceworker-cache-polyfill": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+			"integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"setprototypeof": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+			"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+		},
+		"settle-promise": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/settle-promise/-/settle-promise-1.0.0.tgz",
+			"integrity": "sha1-aXrbWLgh84fOJ1fAbvyd5fDuM9g="
+		},
+		"sha.js": {
+			"version": "2.4.8",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+			"integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"requires": {
+				"array-filter": "0.0.1",
+				"array-map": "0.0.0",
+				"array-reduce": "0.0.0",
+				"jsonify": "0.0.0"
+			}
+		},
+		"shellwords": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
+			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"slice-ansi": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+		},
+		"slide": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"sockjs": {
+			"version": "0.3.18",
+			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+			"integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
+			"requires": {
+				"faye-websocket": "0.10.0",
+				"uuid": "2.0.3"
+			},
+			"dependencies": {
+				"faye-websocket": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+					"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+					"requires": {
+						"websocket-driver": "0.6.5"
+					}
+				},
+				"uuid": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+				}
+			}
+		},
+		"sockjs-client": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+			"requires": {
+				"debug": "2.6.8",
+				"eventsource": "0.1.6",
+				"faye-websocket": "0.11.1",
+				"inherits": "2.0.3",
+				"json3": "3.3.2",
+				"url-parse": "1.1.9"
+			}
+		},
+		"sort-keys": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+			"requires": {
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"source-list-map": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+			"integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY="
+		},
+		"source-map": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+		},
+		"source-map-support": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+			"requires": {
+				"source-map": "0.5.6"
+			}
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+		},
+		"spdy": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"requires": {
+				"debug": "2.6.8",
+				"handle-thing": "1.2.5",
+				"http-deceiver": "1.2.7",
+				"safe-buffer": "5.1.1",
+				"select-hose": "2.0.0",
+				"spdy-transport": "2.0.20"
+			}
+		},
+		"spdy-transport": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+			"integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+			"requires": {
+				"debug": "2.6.8",
+				"detect-node": "2.0.3",
+				"hpack.js": "2.1.6",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.3",
+				"safe-buffer": "5.1.1",
+				"wbuf": "1.7.2"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"statuses": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+		},
+		"stream-browserify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"stream-http": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+			"requires": {
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"string-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"requires": {
+				"strip-ansi": "3.0.1"
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+			"requires": {
+				"get-stdin": "4.0.1"
+			}
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"style-loader": {
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
+			"integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
+			"requires": {
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0"
+			}
+		},
+		"supports-color": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+			"integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+			"requires": {
+				"has-flag": "2.0.0"
+			}
+		},
+		"svgo": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+			"requires": {
+				"coa": "1.0.4",
+				"colors": "1.1.2",
+				"csso": "2.3.2",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"sax": "1.2.4",
+				"whet.extend": "0.9.9"
+			}
+		},
+		"sw-precache": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.0.tgz",
+			"integrity": "sha512-sKctdX+5hUxkqJ/1DM88ubQ+QRvyw7CnxWdk909N2DgvxMqc1gcQFrwL7zpVc87wFmCA/OvRQd0iMC2XdFopYg==",
+			"requires": {
+				"dom-urls": "1.1.0",
+				"es6-promise": "4.1.1",
+				"glob": "7.1.2",
+				"lodash.defaults": "4.2.0",
+				"lodash.template": "4.4.0",
+				"meow": "3.7.0",
+				"mkdirp": "0.5.1",
+				"pretty-bytes": "4.0.2",
+				"sw-toolbox": "3.6.0",
+				"update-notifier": "1.0.3"
+			}
+		},
+		"sw-precache-webpack-plugin": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/sw-precache-webpack-plugin/-/sw-precache-webpack-plugin-0.11.4.tgz",
+			"integrity": "sha1-ppUBflTu1XVVFJOlGdwdqNotxeA=",
+			"requires": {
+				"del": "2.2.2",
+				"sw-precache": "5.2.0",
+				"uglify-js": "3.0.27"
+			}
+		},
+		"sw-toolbox": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+			"integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+			"requires": {
+				"path-to-regexp": "1.7.0",
+				"serviceworker-cache-polyfill": "4.0.0"
+			}
+		},
+		"symbol-observable": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+			"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"table": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
+			"integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+			"requires": {
+				"ajv": "4.11.8",
+				"ajv-keywords": "1.5.1",
+				"chalk": "1.1.3",
+				"lodash": "4.17.4",
+				"slice-ansi": "0.0.4",
+				"string-width": "2.1.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				}
+			}
+		},
+		"tapable": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+		},
+		"test-exclude": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+			"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+			"requires": {
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
+			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"throat": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"thunky": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+			"integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
+		},
+		"time-stamp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
+		},
+		"timed-out": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+			"integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+		},
+		"timers-browserify": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+			"integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+			"requires": {
+				"setimmediate": "1.0.5"
+			}
+		},
+		"tmp": {
+			"version": "0.0.31",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+		},
+		"to-arraybuffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+		},
+		"toposort": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz",
+			"integrity": "sha1-8CzYp0vYvi/A6YYRw7rLlaFxhpw="
+		},
+		"tough-cookie": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"tryit": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+		},
+		"tty-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-is": {
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.16"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"ua-parser-js": {
+			"version": "0.7.14",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+		},
+		"uglify-js": {
+			"version": "3.0.27",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+			"integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+			"requires": {
+				"commander": "2.11.0",
+				"source-map": "0.5.6"
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"optional": true
+		},
+		"uglifyjs-webpack-plugin": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+			"requires": {
+				"source-map": "0.5.6",
+				"uglify-js": "2.8.29",
+				"webpack-sources": "1.0.1"
+			},
+			"dependencies": {
+				"uglify-js": {
+					"version": "2.8.29",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"requires": {
+						"source-map": "0.5.6",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					}
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uniq": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+		},
+		"uniqid": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+			"requires": {
+				"macaddress": "0.2.8"
+			}
+		},
+		"uniqs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+		},
+		"universalify": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"unzip-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+			"integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+		},
+		"update-notifier": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+			"integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+			"requires": {
+				"boxen": "0.6.0",
+				"chalk": "1.1.3",
+				"configstore": "2.1.0",
+				"is-npm": "1.0.0",
+				"latest-version": "2.0.0",
+				"lazy-req": "1.1.0",
+				"semver-diff": "2.1.0",
+				"xdg-basedir": "2.0.0"
+			}
+		},
+		"upper-case": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+		},
+		"urijs": {
+			"version": "1.18.12",
+			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.12.tgz",
+			"integrity": "sha512-WlvUkocbQ+GYhi8zkcbecbGYq7YLSd2I3InxAfqeh6mWvWalBE7bISDHcAL3J7STrWFfizuJ709srHD+RuABPQ=="
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
+		"url-loader": {
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+			"integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
+			"requires": {
+				"loader-utils": "1.1.0",
+				"mime": "1.3.6"
+			}
+		},
+		"url-parse": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+			"integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+			"requires": {
+				"querystringify": "1.0.0",
+				"requires-port": "1.0.0"
+			},
+			"dependencies": {
+				"querystringify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+					"integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+				}
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"requires": {
+				"prepend-http": "1.0.4"
+			}
+		},
+		"util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"requires": {
+				"inherits": "2.0.1"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+				}
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"utila": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
+		},
+		"utils-merge": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+			"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+		},
+		"uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"vary": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+			"integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+		},
+		"vendors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+			"integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"vm-browserify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+			"requires": {
+				"indexof": "0.0.1"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"requires": {
+				"makeerror": "1.0.11"
+			}
+		},
+		"watch": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+		},
+		"watchpack": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+			"requires": {
+				"async": "2.5.0",
+				"chokidar": "1.7.0",
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"wbuf": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+			"requires": {
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"webpack": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.1.tgz",
+			"integrity": "sha1-t0nuPStaEY2tU+jkFYWz9x51SZo=",
+			"requires": {
+				"acorn": "5.1.1",
+				"acorn-dynamic-import": "2.0.2",
+				"ajv": "5.2.2",
+				"ajv-keywords": "2.1.0",
+				"async": "2.5.0",
+				"enhanced-resolve": "3.4.1",
+				"escope": "3.6.0",
+				"interpret": "1.0.3",
+				"json-loader": "0.5.7",
+				"json5": "0.5.1",
+				"loader-runner": "2.3.0",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"mkdirp": "0.5.1",
+				"node-libs-browser": "2.0.0",
+				"source-map": "0.5.6",
+				"supports-color": "4.2.1",
+				"tapable": "0.2.8",
+				"uglifyjs-webpack-plugin": "0.4.6",
+				"watchpack": "1.4.0",
+				"webpack-sources": "1.0.1",
+				"yargs": "8.0.2"
+			},
+			"dependencies": {
+				"ajv-keywords": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+					"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"requires": {
+						"camelcase": "4.1.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
+			}
+		},
+		"webpack-dev-middleware": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
+			"integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+			"requires": {
+				"memory-fs": "0.4.1",
+				"mime": "1.3.6",
+				"path-is-absolute": "1.0.1",
+				"range-parser": "1.2.0",
+				"time-stamp": "2.0.0"
+			}
+		},
+		"webpack-dev-server": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.7.1.tgz",
+			"integrity": "sha1-IVgPWgjNBlxxFEz29hw0W8pZqLg=",
+			"requires": {
+				"ansi-html": "0.0.7",
+				"bonjour": "3.5.0",
+				"chokidar": "1.7.0",
+				"compression": "1.7.0",
+				"connect-history-api-fallback": "1.3.0",
+				"del": "3.0.0",
+				"express": "4.15.4",
+				"html-entities": "1.2.1",
+				"http-proxy-middleware": "0.17.4",
+				"internal-ip": "1.2.0",
+				"ip": "1.1.5",
+				"loglevel": "1.4.1",
+				"opn": "4.0.2",
+				"portfinder": "1.0.13",
+				"selfsigned": "1.10.1",
+				"serve-index": "1.9.0",
+				"sockjs": "0.3.18",
+				"sockjs-client": "1.1.4",
+				"spdy": "3.4.7",
+				"strip-ansi": "3.0.1",
+				"supports-color": "3.2.3",
+				"webpack-dev-middleware": "1.12.0",
+				"yargs": "6.6.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"del": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+					"requires": {
+						"globby": "6.1.0",
+						"is-path-cwd": "1.0.0",
+						"is-path-in-cwd": "1.0.0",
+						"p-map": "1.1.1",
+						"pify": "3.0.0",
+						"rimraf": "2.6.1"
+					}
+				},
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"requires": {
+						"array-union": "1.0.2",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"opn": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+					"requires": {
+						"object-assign": "4.1.1",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "4.2.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"requires": {
+						"camelcase": "3.0.0"
+					}
+				}
+			}
+		},
+		"webpack-manifest-plugin": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-1.2.1.tgz",
+			"integrity": "sha512-9oLMhGlez5JSRv0dWCoxGHHdrYWrDJa8gIHeMFVuY8Fp4noQebXyFlE3fFE/BCYC4C1rG3RyEBPz0aWq1dtYDw==",
+			"requires": {
+				"fs-extra": "0.30.0",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "0.30.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"jsonfile": "2.4.0",
+						"klaw": "1.3.1",
+						"path-is-absolute": "1.0.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "4.1.11"
+					}
+				}
+			}
+		},
+		"webpack-sources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+			"requires": {
+				"source-list-map": "2.0.0",
+				"source-map": "0.5.6"
+			},
+			"dependencies": {
+				"source-list-map": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+					"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+				}
+			}
+		},
+		"websocket-driver": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+			"integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+			"requires": {
+				"websocket-extensions": "0.1.1"
+			}
+		},
+		"websocket-extensions": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+			"integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
+		},
+		"whatwg-encoding": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+			"integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+			"requires": {
+				"iconv-lite": "0.4.13"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+					"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+				}
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		},
+		"whatwg-url": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+			"requires": {
+				"tr46": "0.0.3",
+				"webidl-conversions": "3.0.1"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+				}
+			}
+		},
+		"whet.extend": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+		},
+		"widest-line": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+			"integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+			"requires": {
+				"string-width": "1.0.2"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"worker-farm": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
+			"integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
+			"requires": {
+				"errno": "0.1.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"requires": {
+				"mkdirp": "0.5.1"
+			}
+		},
+		"write-file-atomic": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"slide": "1.1.6"
+			}
+		},
+		"xdg-basedir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+			"integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+			"requires": {
+				"os-homedir": "1.0.2"
+			}
+		},
+		"xml-char-classes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+			"integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
+		},
+		"xml-name-validator": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+			"requires": {
+				"camelcase": "3.0.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "1.4.0",
+				"read-pkg-up": "1.0.1",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "1.0.2",
+				"which-module": "1.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "5.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+			"requires": {
+				"camelcase": "3.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				}
+			}
+		}
+	}
+}

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "counter",
+  "version": "0.0.1",
+  "private": true,
+  "devDependencies": {
+    "react-scripts": "^1.0.2"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "redux": "^3.7.2",
+    "redux-subspace": "^2.0.1-alpha"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "eject": "react-scripts eject"
+  }
+}

--- a/examples/counter/public/index.html
+++ b/examples/counter/public/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Redux Subspace Counter Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+      To begin the development, run `npm start` in this folder.
+      To create a production bundle, use `npm run build`.
+    -->
+  </body>
+</html>

--- a/examples/counter/src/components/Counter.js
+++ b/examples/counter/src/components/Counter.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+class Counter extends Component {
+  constructor(props) {
+    super(props);
+    this.incrementAsync = this.incrementAsync.bind(this);
+    this.incrementIfOdd = this.incrementIfOdd.bind(this);
+  }
+
+  incrementIfOdd() {
+    if (this.props.value % 2 !== 0) {
+      this.props.onIncrement()
+    }
+  }
+
+  incrementAsync() {
+    setTimeout(this.props.onIncrement, 1000)
+  }
+
+  render() {
+    const { value, onIncrement, onDecrement } = this.props
+    return (
+      <p>
+        Clicked: {value} times
+        {' '}
+        <button onClick={onIncrement}>
+          +
+        </button>
+        {' '}
+        <button onClick={onDecrement}>
+          -
+        </button>
+        {' '}
+        <button onClick={this.incrementIfOdd}>
+          Increment if odd
+        </button>
+        {' '}
+        <button onClick={this.incrementAsync}>
+          Increment async
+        </button>
+      </p>
+    )
+  }
+}
+
+Counter.propTypes = {
+  value: PropTypes.number.isRequired,
+  onIncrement: PropTypes.func.isRequired,
+  onDecrement: PropTypes.func.isRequired
+}
+
+export default Counter

--- a/examples/counter/src/index.js
+++ b/examples/counter/src/index.js
@@ -1,0 +1,32 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { createStore } from "redux";
+import { subspace } from "redux-subspace";
+import Counter from "./components/Counter";
+import reducer from "./reducers";
+
+const store = createStore(reducer);
+const rootEl = document.getElementById("root");
+
+const counter1Store = subspace(state => state.counter1, "counter1")(store);
+const counter2Store = subspace(state => state.counter2, "counter2")(store);
+
+const render = () => {
+  ReactDOM.render(
+    <div>
+      <Counter
+        value={counter1Store.getState()}
+        onIncrement={() => counter1Store.dispatch({ type: "INCREMENT" })}
+        onDecrement={() => counter1Store.dispatch({ type: "DECREMENT" })}
+      />
+      <Counter
+        value={counter2Store.getState()}
+        onIncrement={() => counter2Store.dispatch({ type: "INCREMENT" })}
+        onDecrement={() => counter2Store.dispatch({ type: "DECREMENT" })}
+      />
+    </div>,
+    rootEl
+  );
+};
+render();
+store.subscribe(render);

--- a/examples/counter/src/reducers/index.js
+++ b/examples/counter/src/reducers/index.js
@@ -1,0 +1,19 @@
+import { combineReducers } from 'redux';
+import { namespaced } from 'redux-subspace';
+
+const counter = (state = 0, action) => {
+  switch (action.type) {
+    case 'INCREMENT':
+      return state + 1
+    case 'DECREMENT':
+      return state - 1
+    default:
+      return state
+  }
+}
+
+
+export default combineReducers({
+  counter1: namespaced('counter1')(counter),
+  counter2: namespaced('counter2')(counter)
+})

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,8 @@
 {
   "lerna": "2.0.0",
   "packages": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "version": "2.0.1-alpha"
 }


### PR DESCRIPTION
This is a pretty basic example based off the most basic example from the Redux repo.

This should act as the template for how all examples are added to the library.

I haven't decided yet if all examples will live at the root level, or if package specific examples will be placed in the package directories, e.g. `packages/redux-subspace-saga/examples`.

The CodeSandbox examples generate automatically from the git repo.  You can see how this would look/work after the merge by using [my fork for the link](https://codesandbox.io/s/github/mpeyper/redux-subspace/tree/master/examples/counter).