### PR TITLE
Bug Fix: Issue when middleware used middleware

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "counter",
-  "version": "0.0.1",
+  "version": "2.0.2-alpha",
   "private": true,
   "devDependencies": {
     "react-scripts": "^1.0.2"
@@ -10,7 +10,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "redux": "^3.7.2",
-    "redux-subspace": "^2.0.1-alpha"
+    "redux-subspace": "^2.0.2-alpha"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todos",
-  "version": "0.0.1",
+  "version": "2.0.2-alpha",
   "private": true,
   "devDependencies": {
     "react-scripts": "^1.0.2"
@@ -10,9 +10,9 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.6",
-    "react-redux-subspace": "^2.0.1-alpha",
+    "react-redux-subspace": "^2.0.2-alpha",
     "redux": "^3.7.2",
-    "redux-subspace": "^2.0.1-alpha"
+    "redux-subspace": "^2.0.2-alpha"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "examples/*"
   ],
-  "version": "2.0.1-alpha"
+  "version": "2.0.2-alpha"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-subspace",
-  "version": "2.0.0",
+  "version": "2.0.2-alpha",
   "description": "Create isolated subspaces of a Redux store",
   "author": "Michael Peyper",
   "contributors": [

--- a/packages/react-redux-subspace/package.json
+++ b/packages/react-redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-subspace",
-  "version": "2.0.1-alpha",
+  "version": "2.0.2-alpha",
   "description": "react-redux Provider extension for redux-subspace",
   "author": "Michael Peyper",
   "contributors": [
@@ -26,7 +26,7 @@
     "hoist-non-react-statics": "^2.2.1",
     "prop-types": "^15.5.0",
     "recompose": "^0.24.0",
-    "redux-subspace": "^2.0.1-alpha"
+    "redux-subspace": "^2.0.2-alpha"
   },
   "peerDependencies": {
     "react": "^15.1",

--- a/packages/redux-subspace-observable/package.json
+++ b/packages/redux-subspace-observable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-subspace-observable",
-  "version": "2.0.1-alpha",
+  "version": "2.0.2-alpha",
   "description": "redux-subspace wrappers for redux-observable",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-subspace.git"
   },
   "dependencies": {
-    "redux-subspace": "^2.0.1-alpha"
+    "redux-subspace": "^2.0.2-alpha"
   },
   "peerDependencies": {
     "redux-observable": "^0.15.0"

--- a/packages/redux-subspace-saga/package.json
+++ b/packages/redux-subspace-saga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-subspace-saga",
-  "version": "2.0.1-alpha",
+  "version": "2.0.2-alpha",
   "description": "redux-subspace wrappers for redux-saga",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-subspace.git"
   },
   "dependencies": {
-    "redux-subspace": "^2.0.1-alpha"
+    "redux-subspace": "^2.0.2-alpha"
   },
   "peerDependencies": {
     "redux-saga": "^0.15.4"

--- a/packages/redux-subspace-wormhole/package.json
+++ b/packages/redux-subspace-wormhole/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-subspace-wormhole",
-  "version": "2.0.1-alpha",
+  "version": "2.0.2-alpha",
   "description": "Create isolated subspaces of a Redux store",
   "author": "Michael Peyper",
   "contributors": [
@@ -23,7 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-subspace.git"
   },
   "dependencies": {
-    "redux-subspace": "^2.0.1-alpha"
+    "redux-subspace": "^2.0.2-alpha"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/packages/redux-subspace/package.json
+++ b/packages/redux-subspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-subspace",
-  "version": "2.0.1-alpha",
+  "version": "2.0.2-alpha",
   "description": "Create isolated subspaces of a Redux store",
   "author": "Michael Peyper",
   "contributors": [

--- a/packages/redux-subspace/src/enhancers/applySubspaceMiddleware.js
+++ b/packages/redux-subspace/src/enhancers/applySubspaceMiddleware.js
@@ -12,14 +12,28 @@ const applySubspaceMiddleware = (...middlewares) => (createSubspace) => (store) 
 
     const subspacedStore = createSubspace(store)
 
-    const chain = middlewares.map((middleware) => middleware(subspacedStore))
+    let getState = subspacedStore.getState
+    let dispatch = subspacedStore.dispatch
+
+    const { namespace, rootStore, subspaceTypes, processAction } = subspacedStore
+
+    const middlewareApi = {
+        getState: (...args) => getState(...args),
+        dispatch: (...args) => dispatch(...args),
+        rootStore,
+        namespace,
+        subspaceTypes,
+        processAction
+    }
+
+    const chain = middlewares.map((middleware) => middleware(middlewareApi))
         .map((pipeline) => typeof pipeline === 'function' ? { dispatch: pipeline } : pipeline)
 
     const getStateChain = chain.map(pipeline => pipeline.getState).filter(pipeline => pipeline)
     const dispatchChain = chain.map(pipeline => pipeline.dispatch).filter(pipeline => pipeline)
 
-    const getState = compose(...getStateChain)(subspacedStore.getState)
-    const dispatch = compose(...dispatchChain)(subspacedStore.dispatch)
+    getState = compose(...getStateChain)(subspacedStore.getState)
+    dispatch = compose(...dispatchChain)(subspacedStore.dispatch)
 
     return {
         ...subspacedStore,

--- a/packages/redux-subspace/src/index.d.ts
+++ b/packages/redux-subspace/src/index.d.ts
@@ -22,19 +22,19 @@ export enum SubspaceType {
 }
 
 export interface ProcessActionCallback<TReturn> {
-    (action: Redux.Action): TReturn
+    (action: Redux.Action): TReturn;
 }
 
 export interface ProcessAction {
-    (action: Redux.Action, callback: ProcessActionCallback<void>): undefined
-    <TReturn>(action: Redux.Action, callback: ProcessActionCallback<TReturn>, defaultValue: TReturn): TReturn
+    (action: Redux.Action, callback: ProcessActionCallback<void>): undefined;
+    <TReturn>(action: Redux.Action, callback: ProcessActionCallback<TReturn>, defaultValue: TReturn): TReturn;
 }
 
 export interface Subspace<TState, TRootState> extends Redux.Store<TState> {
     rootStore: Redux.Store<TRootState>;
     namespace: string;
     subspaceTypes: SubspaceType[];
-    processAction: ProcessAction
+    processAction: ProcessAction;
 }
 
 export interface StoreDecorator<TParentState, TState, TStore extends Redux.Store<TState>> {
@@ -68,6 +68,7 @@ export function namespaced(namespace: string): ReducerDecorator;
 /**
  * Middleware
  */
+
 export type GetState<TState> = () => TState;
 
 export interface GetStateMiddleware<TState> {
@@ -78,8 +79,17 @@ export interface DispatchMiddleware<TState> {
     (next: Redux.Dispatch<TState>): Redux.Dispatch<TState>;
 }
 
+export interface SubspaceMiddlewareAPI<TState, TRootState> {
+    getState: GetState<TState>;
+    dispatch: Redux.Dispatch<TState>;
+    rootStore: Redux.Store<TRootState>;
+    namespace: string;
+    subspaceTypes: SubspaceType[];
+    processAction: ProcessAction;
+}
+
 export interface SubspaceMiddleware {
-    <TState>(subspace: Subspace<TState, any>): ({ getState?: GetStateMiddleware<TState>, dispatch?: DispatchMiddleware<TState> });
+    <TState>(subspace: SubspaceMiddlewareAPI<TState, any>): ({ getState?: GetStateMiddleware<TState>, dispatch?: DispatchMiddleware<TState> });
 }
 
 export function applyMiddleware(...middlewares: (SubspaceMiddleware | Redux.Middleware)[]): Redux.GenericStoreEnhancer;

--- a/packages/redux-subspace/test/enhancers/applySubspaceMiddleware-spec.js
+++ b/packages/redux-subspace/test/enhancers/applySubspaceMiddleware-spec.js
@@ -15,7 +15,8 @@ describe('applySubspaceMiddleware tests', () => {
 
         const subspace = {
             getState: sinon.stub().returns({ value: 'expected' }),
-            dispatch: sinon.spy()
+            dispatch: sinon.spy(),
+            namespace: 'test'
         }
 
         const middlewareSpy = sinon.spy()
@@ -23,7 +24,7 @@ describe('applySubspaceMiddleware tests', () => {
         const middleware = (store) => ({
             getState: (next) => () => {
                 const state = next()
-                middlewareSpy(store, state)
+                middlewareSpy(store.namespace, state)
                 return state
             }
         })
@@ -33,7 +34,7 @@ describe('applySubspaceMiddleware tests', () => {
         const enhancedSubspace = applySubspaceMiddleware(middleware)(createSubspace)(store)
 
         expect(enhancedSubspace.getState()).to.deep.equal({ value: 'expected' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { value: 'expected' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { value: 'expected' })
     })
 
     it('should enhance getState with multiple middlewares', () => {
@@ -41,7 +42,8 @@ describe('applySubspaceMiddleware tests', () => {
 
         const subspace = {
             getState: sinon.stub().returns({ value: 'expected' }),
-            dispatch: sinon.spy()
+            dispatch: sinon.spy(),
+            namespace: 'test'
         }
 
         const middlewareSpy = sinon.spy()
@@ -49,7 +51,7 @@ describe('applySubspaceMiddleware tests', () => {
         const middleware1 = (store) => ({
             getState: (next) => () => {
                 const state = next()
-                middlewareSpy(store, state)
+                middlewareSpy(store.namespace, state)
                 return state
             }
         })
@@ -57,7 +59,7 @@ describe('applySubspaceMiddleware tests', () => {
         const middleware2 = (store) => ({
             getState: (next) => () => {
                 const state = next()
-                middlewareSpy(store, state)
+                middlewareSpy(store.namespace, state)
                 return { value: 'new value' }
             }
         })
@@ -67,8 +69,8 @@ describe('applySubspaceMiddleware tests', () => {
         const enhancedSubspace = applySubspaceMiddleware(middleware1, middleware2)(createSubspace)(store)
 
         expect(enhancedSubspace.getState()).to.deep.equal({ value: 'new value' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { value: 'expected' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { value: 'new value' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { value: 'expected' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { value: 'new value' })
     })
 
     it('should enhance dispatch with middleware', () => {
@@ -76,14 +78,15 @@ describe('applySubspaceMiddleware tests', () => {
 
         const subspace = {
             getState: sinon.stub().returns({ value: 'expected' }),
-            dispatch: sinon.spy()
+            dispatch: sinon.spy(),
+            namespace: 'test'
         }
 
         const middlewareSpy = sinon.spy()
 
         const middleware = (store) => ({
             dispatch: (next) => (action) => {
-                middlewareSpy(store, action)
+                middlewareSpy(store.namespace, action)
                 return next(action)
             }
         })
@@ -95,7 +98,7 @@ describe('applySubspaceMiddleware tests', () => {
         enhancedSubspace.dispatch({ type: 'TEST' })
 
         expect(subspace.dispatch).to.be.calledWithMatch({ type: 'TEST' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { type: 'TEST' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { type: 'TEST' })
     })
 
     it('should enhance dispatch with multiple middlewares', () => {
@@ -103,21 +106,22 @@ describe('applySubspaceMiddleware tests', () => {
 
         const subspace = {
             getState: sinon.stub().returns({ value: 'expected' }),
-            dispatch: sinon.spy()
+            dispatch: sinon.spy(),
+            namespace: 'test'
         }
 
         const middlewareSpy = sinon.spy()
 
         const middleware1 = (store) => ({
             dispatch: (next) => (action) => {
-                middlewareSpy(store, action)
+                middlewareSpy(store.namespace, action)
                 return next({ type: 'NEW_TYPE' })
             }
         })
 
         const middleware2 = (store) => ({
             dispatch: (next) => (action) => {
-                middlewareSpy(store, action)
+                middlewareSpy(store.namespace, action)
                 return next(action)
             }
         })
@@ -129,8 +133,8 @@ describe('applySubspaceMiddleware tests', () => {
         enhancedSubspace.dispatch({ type: 'TEST' })
 
         expect(subspace.dispatch).to.be.calledWithMatch({ type: 'NEW_TYPE' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { type: 'TEST' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { type: 'NEW_TYPE' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { type: 'TEST' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { type: 'NEW_TYPE' })
     })
 
     it('should treat redux style middleware as dispatch middleware', () => {
@@ -138,13 +142,14 @@ describe('applySubspaceMiddleware tests', () => {
 
         const subspace = {
             getState: sinon.stub().returns({ value: 'expected' }),
-            dispatch: sinon.spy()
+            dispatch: sinon.spy(),
+            namespace: 'test'
         }
 
         const middlewareSpy = sinon.spy()
 
         const middleware = (store) => (next) => (action) => {
-            middlewareSpy(store, action)
+            middlewareSpy(store.namespace, action)
             return next(action)
         }
     
@@ -155,7 +160,7 @@ describe('applySubspaceMiddleware tests', () => {
         enhancedSubspace.dispatch({ type: 'TEST' })
 
         expect(subspace.dispatch).to.be.calledWithMatch({ type: 'TEST' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { type: 'TEST' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { type: 'TEST' })
     })
 
     it('should enhance getState and dispatch with middleware', () => {
@@ -163,7 +168,8 @@ describe('applySubspaceMiddleware tests', () => {
 
         const subspace = {
             getState: sinon.stub().returns({ value: 'expected' }),
-            dispatch: sinon.spy()
+            dispatch: sinon.spy(),
+            namespace: 'test'
         }
 
         const middlewareSpy = sinon.spy()
@@ -171,11 +177,11 @@ describe('applySubspaceMiddleware tests', () => {
         const middleware = (store) => ({
             getState: (next) => () => {
                 const state = next()
-                middlewareSpy(store, state)
+                middlewareSpy(store.namespace, state)
                 return state
             },
             dispatch: (next) => (action) => {
-                middlewareSpy(store, action)
+                middlewareSpy(store.namespace, action)
                 return next(action)
             }
         })
@@ -187,7 +193,7 @@ describe('applySubspaceMiddleware tests', () => {
         enhancedSubspace.dispatch({ type: 'TEST' })
 
         expect(enhancedSubspace.getState()).to.deep.equal({ value: 'expected' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { value: 'expected' })
-        expect(middlewareSpy).to.be.calledWithMatch(subspace, { type: 'TEST' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { value: 'expected' })
+        expect(middlewareSpy).to.be.calledWithMatch('test', { type: 'TEST' })
     })
 })

--- a/packages/redux-subspace/test/middleware/integration/redux-promise.js
+++ b/packages/redux-subspace/test/middleware/integration/redux-promise.js
@@ -149,7 +149,7 @@ describe('redux-promise', () => {
     it('should work with namespaced single subspace', (done) => {
         const rootStore = createStore(rootReducer, applyMiddleware(promiseMiddleware))
 
-        const parentStore = subspace((state) => state.parent1, 'parentNamespace')(rootStore)
+        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
 
         const rootPromise = Promise.resolve('root value')
         
@@ -191,9 +191,9 @@ describe('redux-promise', () => {
     it('should work with namespaced nested subspaces', (done) => {
         const rootStore = createStore(rootReducer, applyMiddleware(promiseMiddleware))
 
-        const parentStore = subspace((state) => state.parent1, 'parentNamespace')(rootStore)
+        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
 
-        const childStore = subspace((state) => state.child1, 'childNamespace')(parentStore)
+        const childStore = subspace((state) => state.child2, 'childNamespace')(parentStore)
 
         const rootPromise = Promise.resolve('root value')
         

--- a/packages/redux-subspace/test/middleware/integration/redux-thunk.js
+++ b/packages/redux-subspace/test/middleware/integration/redux-thunk.js
@@ -199,4 +199,28 @@ describe('redux-thunk', () => {
             }
         })
     })
+    
+    it('should work with nested thunks', () => {
+
+        const rootStore = createStore(rootReducer, applyMiddleware(thunk))
+
+        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
+
+        const childStore = subspace((state) => state.child2, 'childNamespace')(parentStore)
+
+        const firstThunk = (dispatch) => dispatch(checkingThunk(childStore, testAction('child value')))
+
+        childStore.dispatch(firstThunk)
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'initial value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'child value'
+            }
+        })
+    })
 })

--- a/packages/redux-subspace/test/store/applyMiddleware-spec.js
+++ b/packages/redux-subspace/test/store/applyMiddleware-spec.js
@@ -8,21 +8,6 @@
 
 import applyMiddleware from '../../src/store/applyMiddleware'
 
-// const applyMiddleware = (...middlewares) => (createStore) => (reducer, preloadedState, enhancer) => {
-//     const store = createStore(reducer, preloadedState, enhancer)
-
-//     const subspaceOptions = {
-//         enhancer: compose(applySubspaceMiddleware(...middlewares))
-//     }
-
-//     const rootStore = subspaceEnhanced((state) => state, undefined, subspaceOptions)(store)
-
-//     return {
-//         ...rootStore,
-//         subspaceOptions
-//     }
-// }
-
 describe('applyMiddleware tests', () => {
 
     it('should maintain root store state', () => {


### PR DESCRIPTION
Basically, if a middleware tried to use middleware (e.g. [thunk dispatching a thunk](https://github.com/ioof-holdings/redux-subspace/pull/41/files#diff-49119f9350fb9b82968e43f8740e434c)), the second middleware would use the parent subspace's scope, not the originating subspace.

This PR fixes that.