### PR TITLE
Fixed null state case for redux-subspace-wormhole

### DIFF
--- a/packages/redux-subspace-wormhole/package-lock.json
+++ b/packages/redux-subspace-wormhole/package-lock.json
@@ -1,16 +1,20 @@
 {
-	"requires": true,
+	"name": "redux-subspace-wormhole",
+	"version": "2.0.2-alpha",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"acorn": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -18,7 +22,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -26,6 +31,7 @@
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"json-stable-stringify": "1.0.1"
@@ -34,27 +40,32 @@
 		"ajv-keywords": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
 			"integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arrify": "1.0.1",
@@ -65,6 +76,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -73,6 +85,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
@@ -82,12 +95,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
 			"optional": true
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -95,18 +110,21 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true,
 			"optional": true
 		},
 		"array.prototype.find": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
 			"integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.7.0"
@@ -115,23 +133,27 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-			"integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+			"integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"babel-cli": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
 			"integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-polyfill": "6.23.0",
@@ -154,6 +176,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -164,6 +187,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
 			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-generator": "6.25.0",
@@ -190,6 +214,7 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
 			"integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+			"dev": true,
 			"requires": {
 				"babel-traverse": "6.25.0",
 				"babel-types": "6.25.0",
@@ -202,6 +227,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
 			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.23.0",
@@ -217,6 +243,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-traverse": "6.25.0",
@@ -227,6 +254,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -237,6 +265,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0",
@@ -247,6 +276,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -258,6 +288,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -269,6 +300,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-traverse": "6.25.0",
@@ -279,6 +311,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -290,6 +323,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -302,6 +336,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0"
@@ -311,6 +346,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0"
@@ -320,6 +356,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0"
@@ -329,6 +366,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0",
@@ -339,6 +377,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -351,6 +390,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -364,6 +404,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-template": "6.25.0"
@@ -373,6 +414,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -381,6 +423,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -388,77 +431,92 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+			"dev": true
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+			"dev": true
 		},
 		"babel-plugin-syntax-do-expressions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
-			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0="
+			"integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-function-bind": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
-			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
+			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -469,6 +527,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -479,6 +538,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "6.18.0",
 				"babel-runtime": "6.23.0",
@@ -489,6 +549,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-plugin-syntax-class-properties": "6.13.0",
@@ -500,6 +561,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "6.24.1",
 				"babel-plugin-syntax-decorators": "6.13.0",
@@ -512,6 +574,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
 			"integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-do-expressions": "6.13.0",
 				"babel-runtime": "6.23.0"
@@ -521,6 +584,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -529,6 +593,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -537,6 +602,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-template": "6.25.0",
@@ -549,6 +615,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.24.1",
 				"babel-helper-function-name": "6.24.1",
@@ -565,6 +632,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-template": "6.25.0"
@@ -574,6 +642,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -582,6 +651,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0"
@@ -591,6 +661,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -599,6 +670,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -609,6 +681,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -617,6 +690,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -627,6 +701,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -638,6 +713,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -648,6 +724,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -658,6 +735,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.23.0"
@@ -667,6 +745,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -680,6 +759,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0"
@@ -689,6 +769,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -697,6 +778,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -707,6 +789,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -715,6 +798,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -723,6 +807,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.23.0",
@@ -733,6 +818,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -743,6 +829,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "6.13.0",
 				"babel-runtime": "6.23.0"
@@ -752,6 +839,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.23.0"
@@ -761,6 +849,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
 			"integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-function-bind": "6.13.0",
 				"babel-runtime": "6.23.0"
@@ -770,6 +859,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
 			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.23.0"
@@ -779,6 +869,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0"
 			}
@@ -787,6 +878,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.24.1",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -797,6 +889,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.23.0"
@@ -806,6 +899,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.23.0"
@@ -815,6 +909,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
 			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.9.11"
 			}
@@ -823,6 +918,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0"
@@ -832,6 +928,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
 			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"core-js": "2.4.1",
@@ -842,6 +939,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -873,6 +971,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -881,6 +980,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -894,6 +994,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
 			"integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-do-expressions": "6.22.0",
 				"babel-plugin-transform-function-bind": "6.22.0",
@@ -904,6 +1005,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "6.24.1",
 				"babel-plugin-transform-export-extensions": "6.22.0",
@@ -914,6 +1016,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "6.18.0",
 				"babel-plugin-transform-class-properties": "6.24.1",
@@ -925,6 +1028,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -937,6 +1041,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
 			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-runtime": "6.23.0",
@@ -951,6 +1056,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
 			"integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.4.1",
 				"regenerator-runtime": "0.10.5"
@@ -960,6 +1066,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-traverse": "6.25.0",
@@ -972,6 +1079,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-messages": "6.23.0",
@@ -988,6 +1096,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"esutils": "2.0.2",
@@ -998,23 +1107,27 @@
 		"babylon": {
 			"version": "6.17.4",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
 			"integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+			"dev": true,
 			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1024,6 +1137,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
@@ -1035,6 +1149,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1042,12 +1157,14 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"chai": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
 			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.0.2",
 				"deep-eql": "0.1.3",
@@ -1058,6 +1175,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1070,6 +1188,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.0",
@@ -1086,12 +1205,14 @@
 		"circular-json": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-			"integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0="
+			"integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "1.0.1"
 			}
@@ -1099,32 +1220,38 @@
 		"cli-width": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.3",
@@ -1134,22 +1261,26 @@
 		"convert-source-map": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"d": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
 			"requires": {
 				"es5-ext": "0.10.24"
 			}
@@ -1158,6 +1289,7 @@
 			"version": "2.6.8",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1166,6 +1298,7 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
 			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"dev": true,
 			"requires": {
 				"type-detect": "0.1.1"
 			},
@@ -1173,19 +1306,22 @@
 				"type-detect": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+					"dev": true
 				}
 			}
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1195,6 +1331,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1209,6 +1346,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1216,12 +1354,14 @@
 		"diff": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
 			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"isarray": "1.0.0"
@@ -1231,6 +1371,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.2.0.tgz",
 			"integrity": "sha1-4WXklLAPgaO262Q4XL9tG0hrepk=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "0.2.0",
 				"glob": "4.5.3",
@@ -1241,6 +1382,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
 					"integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "0.1.0",
 						"minimist": "0.1.0"
@@ -1250,6 +1392,7 @@
 					"version": "4.5.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1261,6 +1404,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
@@ -1268,7 +1412,8 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
@@ -1276,6 +1421,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
 			"integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.0",
@@ -1287,6 +1433,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1297,6 +1444,7 @@
 			"version": "0.10.24",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
 			"integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=",
+			"dev": true,
 			"requires": {
 				"es6-iterator": "2.0.1",
 				"es6-symbol": "3.1.1"
@@ -1306,6 +1454,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
 			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.24",
@@ -1316,6 +1465,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.24",
@@ -1329,6 +1479,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.24",
@@ -1341,6 +1492,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.24"
@@ -1350,6 +1502,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.24",
@@ -1360,12 +1513,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escope": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"dev": true,
 			"requires": {
 				"es6-map": "0.1.5",
 				"es6-weak-map": "2.0.2",
@@ -1377,6 +1532,7 @@
 			"version": "3.19.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
 			"integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"chalk": "1.1.3",
@@ -1419,6 +1575,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 					"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+					"dev": true,
 					"requires": {
 						"os-homedir": "1.0.2"
 					}
@@ -1429,6 +1586,7 @@
 			"version": "6.10.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
 			"integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+			"dev": true,
 			"requires": {
 				"array.prototype.find": "2.0.4",
 				"doctrine": "1.5.0",
@@ -1441,6 +1599,7 @@
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
 						"isarray": "1.0.0"
@@ -1452,6 +1611,7 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
 			"integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+			"dev": true,
 			"requires": {
 				"acorn": "5.1.1",
 				"acorn-jsx": "3.0.1"
@@ -1460,12 +1620,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1474,6 +1636,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0",
 				"object-assign": "4.1.1"
@@ -1482,17 +1645,20 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.24"
@@ -1501,12 +1667,14 @@
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
@@ -1516,6 +1684,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "2.2.3"
@@ -1525,6 +1694,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
@@ -1533,12 +1703,14 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"figures": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5",
 				"object-assign": "4.1.1"
@@ -1548,6 +1720,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.2.2",
 				"object-assign": "4.1.1"
@@ -1557,12 +1730,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -1576,6 +1751,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
 			"integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.1",
 				"del": "2.2.2",
@@ -1587,12 +1763,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
 			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
@@ -1601,12 +1779,14 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"formatio": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
 			"integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+			"dev": true,
 			"requires": {
 				"samsam": "1.1.2"
 			}
@@ -1614,17 +1794,20 @@
 		"fs-readdir-recursive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
 			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.6.2",
@@ -1634,11 +1817,13 @@
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1647,16 +1832,19 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1666,35 +1854,42 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1703,6 +1898,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1710,6 +1906,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1717,6 +1914,7 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1724,44 +1922,53 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"boom": "2.10.1"
@@ -1770,6 +1977,7 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1778,6 +1986,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -1785,6 +1994,7 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1793,20 +2003,24 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1815,20 +2029,24 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -1838,11 +2056,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1853,6 +2073,7 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1863,6 +2084,7 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -1878,6 +2100,7 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1886,6 +2109,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -1893,6 +2117,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -1904,16 +2129,19 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -1923,11 +2151,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"boom": "2.10.1",
@@ -1938,11 +2168,13 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -1953,6 +2185,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -1960,16 +2193,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -1977,20 +2213,24 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1999,16 +2239,19 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2017,16 +2260,19 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2038,17 +2284,20 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -2056,17 +2305,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2074,11 +2326,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.36",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"mkdirp": "0.5.1",
@@ -2095,6 +2349,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2104,6 +2359,7 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2114,21 +2370,25 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2136,16 +2396,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2154,30 +2417,36 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2189,6 +2458,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2196,6 +2466,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2209,6 +2480,7 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2238,32 +2510,38 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"hoek": "2.16.3"
@@ -2272,6 +2550,7 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2288,6 +2567,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2295,6 +2575,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2302,6 +2583,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2311,11 +2593,13 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2323,11 +2607,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2337,6 +2623,7 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2352,6 +2639,7 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2360,6 +2648,7 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2368,25 +2657,30 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2395,6 +2689,7 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2402,24 +2697,28 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
 			"requires": {
 				"is-property": "1.0.2"
 			}
@@ -2427,12 +2726,14 @@
 		"get-stdin": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2446,6 +2747,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
@@ -2456,6 +2758,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2463,12 +2766,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2481,17 +2786,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.0"
 			}
@@ -2500,6 +2808,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2508,6 +2817,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2516,17 +2826,20 @@
 		"ignore": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0="
+			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2535,12 +2848,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
 			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "1.4.0",
 				"ansi-regex": "2.1.1",
@@ -2560,12 +2875,14 @@
 		"interpret": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -2574,6 +2891,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.8.0"
@@ -2582,28 +2900,33 @@
 		"is-buffer": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
@@ -2613,17 +2936,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
 			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2632,6 +2958,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2640,6 +2967,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2648,6 +2976,7 @@
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
 			"integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+			"dev": true,
 			"requires": {
 				"generate-function": "2.0.0",
 				"generate-object-property": "1.2.0",
@@ -2659,6 +2988,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -2667,12 +2997,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.0"
 			}
@@ -2681,6 +3013,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -2689,22 +3022,26 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -2713,6 +3050,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
 			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+			"dev": true,
 			"requires": {
 				"tryit": "1.0.3"
 			}
@@ -2720,17 +3058,20 @@
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -2740,6 +3081,7 @@
 			"version": "0.26.3",
 			"resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
 			"integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+			"dev": true,
 			"requires": {
 				"commander": "0.6.1",
 				"mkdirp": "0.3.0"
@@ -2748,24 +3090,28 @@
 				"commander": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-					"integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+					"integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-					"integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+					"integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+					"dev": true
 				}
 			}
 		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
 			"integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.9",
 				"esprima": "4.0.0"
@@ -2774,12 +3120,14 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
 			"requires": {
 				"jsonify": "0.0.0"
 			}
@@ -2787,27 +3135,32 @@
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
 		},
 		"jsx-ast-utils": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.5"
 			}
@@ -2816,6 +3169,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -2824,32 +3178,43 @@
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"dev": true
 		},
 		"lodash-es": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.pickby": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+			"dev": true
 		},
 		"lolex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-			"integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
+			"integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -2857,12 +3222,14 @@
 		"lru-cache": {
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
@@ -2884,6 +3251,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.8"
 			}
@@ -2891,12 +3259,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -2905,6 +3275,7 @@
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
 			"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+			"dev": true,
 			"requires": {
 				"commander": "2.3.0",
 				"debug": "2.2.0",
@@ -2921,12 +3292,14 @@
 				"commander": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+					"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+					"dev": true
 				},
 				"debug": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
 					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+					"dev": true,
 					"requires": {
 						"ms": "0.7.1"
 					}
@@ -2934,12 +3307,14 @@
 				"escape-string-regexp": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+					"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+					"dev": true
 				},
 				"glob": {
 					"version": "3.2.11",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
 					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3",
 						"minimatch": "0.3.0"
@@ -2949,6 +3324,7 @@
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
 					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"dev": true,
 					"requires": {
 						"lru-cache": "2.7.3",
 						"sigmund": "1.0.1"
@@ -2957,40 +3333,47 @@
 				"ms": {
 					"version": "0.7.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
+					"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+					"dev": true
 				}
 			}
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
 			"integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"remove-trailing-separator": "1.0.2"
@@ -2999,12 +3382,14 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nyc": {
 			"version": "10.3.2",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-10.3.2.tgz",
 			"integrity": "sha1-8n9NkfKp2zbCT1dP9cbv/wIz3kY=",
+			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3038,6 +3423,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.0",
 						"longest": "1.0.1",
@@ -3046,53 +3432,64 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "1.0.3"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.22.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -3102,6 +3499,7 @@
 				"babel-generator": {
 					"version": "6.24.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.23.0",
@@ -3116,6 +3514,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.23.0"
 					}
@@ -3123,6 +3522,7 @@
 				"babel-runtime": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "2.4.1",
 						"regenerator-runtime": "0.10.5"
@@ -3131,6 +3531,7 @@
 				"babel-template": {
 					"version": "6.24.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.23.0",
 						"babel-traverse": "6.24.1",
@@ -3142,6 +3543,7 @@
 				"babel-traverse": {
 					"version": "6.24.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.22.0",
 						"babel-messages": "6.23.0",
@@ -3157,6 +3559,7 @@
 				"babel-types": {
 					"version": "6.24.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.23.0",
 						"esutils": "2.0.2",
@@ -3166,15 +3569,18 @@
 				},
 				"babylon": {
 					"version": "6.17.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -3183,6 +3589,7 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3191,11 +3598,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -3205,11 +3614,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -3219,6 +3630,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3230,6 +3642,7 @@
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -3240,33 +3653,40 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.4.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "4.0.2",
 						"which": "1.2.14"
@@ -3275,21 +3695,25 @@
 				"debug": {
 					"version": "2.6.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "0.7.3"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -3297,6 +3721,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -3304,21 +3729,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3326,6 +3755,7 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -3333,17 +3763,20 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -3355,6 +3788,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -3364,6 +3798,7 @@
 				"find-up": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-exists": "2.1.0",
 						"pinkie-promise": "2.0.1"
@@ -3371,11 +3806,13 @@
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -3383,6 +3820,7 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -3390,15 +3828,18 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -3411,6 +3852,7 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -3419,21 +3861,25 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.17.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -3444,6 +3890,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -3453,25 +3900,30 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -3479,56 +3931,67 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3536,6 +3999,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3543,6 +4007,7 @@
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3550,44 +4015,53 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.0"
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -3595,6 +4069,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.7.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "6.24.1",
 						"babel-template": "6.24.1",
@@ -3608,6 +4083,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.0",
 						"mkdirp": "0.5.1",
@@ -3618,6 +4094,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -3627,6 +4104,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "2.6.6",
 						"istanbul-lib-coverage": "1.1.0",
@@ -3638,21 +4116,25 @@
 				"istanbul-reports": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "4.0.8"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.5"
 					}
@@ -3660,11 +4142,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -3672,6 +4156,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -3682,15 +4167,18 @@
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.1"
 					}
@@ -3698,6 +4186,7 @@
 				"lru-cache": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -3706,17 +4195,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"merge-source-map": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.6"
 					}
@@ -3724,6 +4216,7 @@
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3743,28 +4236,33 @@
 				"minimatch": {
 					"version": "3.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "0.7.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.3.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.4.2",
 						"is-builtin-module": "1.0.0",
@@ -3775,21 +4273,25 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -3798,6 +4300,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -3805,6 +4308,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -3812,11 +4316,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lcid": "1.0.0"
 					}
@@ -3824,6 +4330,7 @@
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.2",
@@ -3834,6 +4341,7 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
@@ -3841,21 +4349,25 @@
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -3864,15 +4376,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -3880,21 +4395,25 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					}
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"kind-of": "3.2.0"
@@ -3903,6 +4422,7 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.3.8",
@@ -3912,6 +4432,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -3919,11 +4440,13 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.10.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3",
 						"is-primitive": "2.0.0"
@@ -3931,38 +4454,46 @@
 				},
 				"remove-trailing-separator": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -3971,33 +4502,40 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.1"
 					}
 				},
 				"semver": {
 					"version": "5.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.2.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -4009,28 +4547,33 @@
 					"dependencies": {
 						"signal-exit": {
 							"version": "2.1.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"spdx-correct": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-license-ids": "1.2.2"
 					}
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -4040,6 +4583,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4047,17 +4591,20 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "2.3.11",
@@ -4068,15 +4615,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.22",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.6",
@@ -4087,6 +4637,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -4100,11 +4651,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "1.0.2",
 						"spdx-expression-parse": "1.0.4"
@@ -4113,26 +4666,31 @@
 				"which": {
 					"version": "1.2.14",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -4140,11 +4698,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -4153,15 +4713,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "7.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "3.0.0",
 						"cliui": "3.2.0",
@@ -4180,11 +4743,13 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
@@ -4196,13 +4761,15 @@
 				"yargs-parser": {
 					"version": "5.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "3.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -4211,17 +4778,20 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
 			"integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"function-bind": "1.1.0",
@@ -4232,6 +4802,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
@@ -4242,6 +4813,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4249,12 +4821,14 @@
 		"onetime": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+			"dev": true
 		},
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4267,17 +4841,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4288,6 +4865,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
@@ -4299,32 +4877,38 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4332,38 +4916,45 @@
 		"pluralize": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"dev": true
 		},
 		"progress": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -4374,6 +4965,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "3.2.2"
@@ -4383,6 +4975,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-buffer": "1.1.5"
@@ -4394,6 +4987,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "1.1.5"
@@ -4405,6 +4999,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4419,6 +5014,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4431,6 +5027,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4441,6 +5038,7 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
 			"requires": {
 				"resolve": "1.3.3"
 			}
@@ -4449,6 +5047,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.4",
 				"lodash-es": "4.17.4",
@@ -4459,22 +5058,26 @@
 		"redux-mock-store": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.2.3.tgz",
-			"integrity": "sha1-GzrSmdqRy0G6MNaOO28CRHX7nhs="
+			"integrity": "sha1-GzrSmdqRy0G6MNaOO28CRHX7nhs=",
+			"dev": true
 		},
 		"regenerate": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.10.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.9.11",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.23.0",
 				"babel-types": "6.25.0",
@@ -4485,6 +5088,7 @@
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3",
@@ -4495,6 +5099,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.2",
 				"regjsgen": "0.2.0",
@@ -4504,12 +5109,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4517,7 +5124,8 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
@@ -4525,23 +5133,27 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
 			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+			"dev": true,
 			"optional": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
 			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4550,6 +5162,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4559,6 +5172,7 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
 			"integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
 			}
@@ -4566,12 +5180,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"dev": true,
 			"requires": {
 				"exit-hook": "1.1.1",
 				"onetime": "1.1.0"
@@ -4581,6 +5197,7 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -4589,6 +5206,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0"
 			}
@@ -4596,28 +5214,33 @@
 		"rx-lite": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"samsam": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-			"integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
+			"integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"shelljs": {
 			"version": "0.7.8",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"interpret": "1.0.3",
@@ -4627,12 +5250,14 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "1.17.7",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
 			"integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+			"dev": true,
 			"requires": {
 				"formatio": "1.1.1",
 				"lolex": "1.3.2",
@@ -4643,27 +5268,32 @@
 		"sinon-chai": {
 			"version": "2.12.0",
 			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.12.0.tgz",
-			"integrity": "sha512-/J38xAWY5ppvRKuSrdnpVv7rWmxjfma9lL/iYaqn+ge/JynkhM9w8PaFAoGvGv+Tj2nEQWkkS8S4Syt4Lw1K6Q=="
+			"integrity": "sha512-/J38xAWY5ppvRKuSrdnpVv7rWmxjfma9lL/iYaqn+ge/JynkhM9w8PaFAoGvGv+Tj2nEQWkkS8S4Syt4Lw1K6Q==",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.15",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
 			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.6"
 			}
@@ -4671,12 +5301,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -4685,6 +5317,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4695,6 +5328,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -4702,27 +5336,32 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-			"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+			"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+			"dev": true
 		},
 		"table": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
 			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+			"dev": true,
 			"requires": {
 				"ajv": "4.11.8",
 				"ajv-keywords": "1.5.1",
@@ -4735,17 +5374,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4755,6 +5397,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -4764,37 +5407,44 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"to-iso-string": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-			"integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE="
+			"integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tryit": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -4802,22 +5452,26 @@
 		"type-detect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-			"integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ="
+			"integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+			"dev": true
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz",
 			"integrity": "sha1-kcV0146gW4HtgSRNUOww2CQMNW8=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.0.2",
 				"dts-bundle": "0.2.0",
@@ -4827,19 +5481,22 @@
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util": {
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.1"
 			},
@@ -4847,19 +5504,22 @@
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
 				}
 			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -4867,17 +5527,20 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -4885,7 +5548,8 @@
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		}
 	}
 }

--- a/packages/redux-subspace-wormhole/package.json
+++ b/packages/redux-subspace-wormhole/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/ioof-holdings/redux-subspace.git"
   },
   "dependencies": {
+    "lodash.isplainobject": "^4.0.6",
     "redux-subspace": "^2.0.2-alpha"
   },
   "devDependencies": {

--- a/packages/redux-subspace-wormhole/src/wormhole.js
+++ b/packages/redux-subspace-wormhole/src/wormhole.js
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import isPlainObject from 'lodash.isplainobject'
+
 const wormhole = (mapState, key) => {
 
     if (typeof mapState === 'string') {
@@ -21,7 +23,7 @@ const wormhole = (mapState, key) => {
         getState: (next) => () => {
             const state = next()
 
-            if (typeof state === 'object' && !Array.isArray(state)) {
+            if (isPlainObject(state)) {
                 return { [key]: mapState(store.rootStore.getState()), ...state }
             } else {
                 return state

--- a/packages/redux-subspace-wormhole/test/wormhole-spec.js
+++ b/packages/redux-subspace-wormhole/test/wormhole-spec.js
@@ -78,7 +78,21 @@ describe('wormhole Tests', () => {
 
         expect(state).to.deep.equal("expected")
     })
+    
+    it('should handle null state', () => {
+        const store = {
+            rootStore: {
+                getState: () => ({ value: "wrong" })
+            }
+        }
 
+        const getState = () => null
+
+        const state = wormhole((state) => state.value, 'extra')(store).getState(getState)()
+
+        expect(state).to.be.null
+    })
+        
     it('should handle undefined state', () => {
         const store = {
             rootStore: {


### PR DESCRIPTION
Found an edge case while working on the real-world example where is the state of a subspace was `null` it was being replaced by the wormhole's state.  This is problematic if the state was not meant to be an object, e.g. primative or array.

I've replaced the object check with [lodash's isPlainObject](https://lodash.com/docs/4.17.4#isPlainObject) which is better at determining what is a plain object, i.e. `{}`,  and what is not.