### PR TITLE
Fix license badge links in packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace.svg?style=flat-square)](LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace.svg?style=flat-square)](/LICENSE.md)
 
 This is a library to create isolated sub-applications within a Redux application.
 

--- a/packages/react-redux-subspace/README.md
+++ b/packages/react-redux-subspace/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/react-redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/react-redux-subspace)
 [![npm downloads](https://img.shields.io/npm/dm/react-redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/react-redux-subspace)
-[![License: MIT](https://img.shields.io/npm/l/react-redux-subspace.svg?style=flat-square)](LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/react-redux-subspace.svg?style=flat-square)](../../LICENSE.md)
 
 This is a library to create subspaces for Redux connected React components. It's designed to work with Provider from the [react-redux](https://github.com/reactjs/react-redux) bindings.
 

--- a/packages/react-redux-subspace/README.md
+++ b/packages/react-redux-subspace/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/react-redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/react-redux-subspace)
 [![npm downloads](https://img.shields.io/npm/dm/react-redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/react-redux-subspace)
-[![License: MIT](https://img.shields.io/npm/l/react-redux-subspace.svg?style=flat-square)](../../LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/react-redux-subspace.svg?style=flat-square)](/LICENSE.md)
 
 This is a library to create subspaces for Redux connected React components. It's designed to work with Provider from the [react-redux](https://github.com/reactjs/react-redux) bindings.
 

--- a/packages/redux-subspace-loop/README.md
+++ b/packages/redux-subspace-loop/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-loop.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-loop)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-loop.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-loop)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-loop.svg?style=flat-square)](LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-loop.svg?style=flat-square)](../../LICENSE.md)
 
 This library provides necessary utilities for supporting redux-subspace in projects using [redux-loop](https://github.com/redux-loop/redux-loop).
 

--- a/packages/redux-subspace-loop/README.md
+++ b/packages/redux-subspace-loop/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-loop.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-loop)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-loop.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-loop)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-loop.svg?style=flat-square)](../../LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-loop.svg?style=flat-square)](/LICENSE.md)
 
 This library provides necessary utilities for supporting redux-subspace in projects using [redux-loop](https://github.com/redux-loop/redux-loop).
 

--- a/packages/redux-subspace-observable/README.md
+++ b/packages/redux-subspace-observable/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-observable.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-observable)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-observable.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-observable)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-observable.svg?style=flat-square)](../../LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-observable.svg?style=flat-square)](/LICENSE.md)
 
 This is a library to create subspaces for epics. It's designed to work with [redux-observable](https://redux-observable.js.org/) middleware.
 

--- a/packages/redux-subspace-observable/README.md
+++ b/packages/redux-subspace-observable/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-observable.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-observable)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-observable.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-observable)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-observable.svg?style=flat-square)](LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-observable.svg?style=flat-square)](../../LICENSE.md)
 
 This is a library to create subspaces for epics. It's designed to work with [redux-observable](https://redux-observable.js.org/) middleware.
 

--- a/packages/redux-subspace-saga/README.md
+++ b/packages/redux-subspace-saga/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-saga.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-saga)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-saga.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-saga)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-saga.svg?style=flat-square)](LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-saga.svg?style=flat-square)](../../LICENSE.md)
 
 This is a library to create subspaces for sagas. It's designed to work with [redux-saga](https://redux-saga.js.org) middleware.
 

--- a/packages/redux-subspace-saga/README.md
+++ b/packages/redux-subspace-saga/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-saga.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-saga)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-saga.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-saga)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-saga.svg?style=flat-square)](../../LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-saga.svg?style=flat-square)](/LICENSE.md)
 
 This is a library to create subspaces for sagas. It's designed to work with [redux-saga](https://redux-saga.js.org) middleware.
 

--- a/packages/redux-subspace-wormhole/README.md
+++ b/packages/redux-subspace-wormhole/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-wormhole.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-wormhole)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-wormhole.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-wormhole)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-wormhole.svg?style=flat-square)](LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-wormhole.svg?style=flat-square)](../../LICENSE.md)
 
 This is a library to inject additional global state into subspaces.
 

--- a/packages/redux-subspace-wormhole/README.md
+++ b/packages/redux-subspace-wormhole/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace-wormhole.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-wormhole)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace-wormhole.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace-wormhole)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace-wormhole.svg?style=flat-square)](../../LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace-wormhole.svg?style=flat-square)](/LICENSE.md)
 
 This is a library to inject additional global state into subspaces.
 

--- a/packages/redux-subspace/README.md
+++ b/packages/redux-subspace/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace.svg?style=flat-square)](../../LICENSE)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace.svg?style=flat-square)](/LICENSE.md)
 
 This is a library to create subspaces for Redux stores. This is the core package of [Redux Subspace](/)
 

--- a/packages/redux-subspace/README.md
+++ b/packages/redux-subspace/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace)
 [![npm downloads](https://img.shields.io/npm/dm/redux-subspace.svg?style=flat-square)](https://www.npmjs.com/package/redux-subspace)
-[![License: MIT](https://img.shields.io/npm/l/redux-subspace.svg?style=flat-square)](LICENSE)
+[![License: MIT](https://img.shields.io/npm/l/redux-subspace.svg?style=flat-square)](../../LICENSE)
 
 This is a library to create subspaces for Redux stores. This is the core package of [Redux Subspace](/)
 


### PR DESCRIPTION
I noticed that if you clicked the license badges they were not pathing to the license at the root