### PR TITLE
Fixed issue when root subspace was composed with redux dev tools

### DIFF
--- a/packages/react-redux-subspace/test/typescript/definitions-spec.js
+++ b/packages/react-redux-subspace/test/typescript/definitions-spec.js
@@ -24,6 +24,6 @@ describe('TypeScript definitions', function () {
   fs.readdirSync(path.join(__dirname, 'definitions')).forEach((filename) => {
     it(`should compile ${path.basename(filename, path.extname(filename))} against index.d.ts`, (done) => {
       tt.compile([path.join(__dirname, 'definitions', filename)], options, done)
-    }).timeout(5000)
+    }).timeout(20000)
   });
 })

--- a/packages/redux-subspace-loop/test/typescript/definitions-spec.js
+++ b/packages/redux-subspace-loop/test/typescript/definitions-spec.js
@@ -23,6 +23,6 @@ describe('TypeScript definitions', function () {
   fs.readdirSync(path.join(__dirname, 'definitions')).forEach((filename) => {
     it(`should compile ${path.basename(filename, path.extname(filename))} against index.d.ts`, (done) => {
       tt.compile([path.join(__dirname, 'definitions', filename)], options, done)
-    }).timeout(5000)
+    }).timeout(20000)
   });
 })

--- a/packages/redux-subspace-observable/test/typescript/definitions-spec.js
+++ b/packages/redux-subspace-observable/test/typescript/definitions-spec.js
@@ -23,6 +23,6 @@ describe('TypeScript definitions', function () {
   fs.readdirSync(path.join(__dirname, 'definitions')).forEach((filename) => {
     it(`should compile ${path.basename(filename, path.extname(filename))} against index.d.ts`, (done) => {
       tt.compile([path.join(__dirname, 'definitions', filename)], options, done)
-    }).timeout(5000)
+    }).timeout(20000)
   });
 })

--- a/packages/redux-subspace-observable/test/typescript/definitions/createEpicMiddleware.ts
+++ b/packages/redux-subspace-observable/test/typescript/definitions/createEpicMiddleware.ts
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createStore, applyMiddleware, Action } from 'redux'
+import { createStore, Action } from 'redux'
+import { applyMiddleware } from 'redux-subspace'
 import { Epic, ActionsObservable } from 'redux-observable'
 import { takeEvery, put } from 'redux-saga/effects'
 import 'rxjs/add/operator/map'

--- a/packages/redux-subspace-saga/test/typescript/definitions-spec.js
+++ b/packages/redux-subspace-saga/test/typescript/definitions-spec.js
@@ -23,6 +23,6 @@ describe('TypeScript definitions', function () {
   fs.readdirSync(path.join(__dirname, 'definitions')).forEach((filename) => {
     it(`should compile ${path.basename(filename, path.extname(filename))} against index.d.ts`, (done) => {
       tt.compile([path.join(__dirname, 'definitions', filename)], options, done)
-    }).timeout(5000)
+    }).timeout(20000)
   });
 })

--- a/packages/redux-subspace-saga/test/typescript/definitions/createSageMiddleware.ts
+++ b/packages/redux-subspace-saga/test/typescript/definitions/createSageMiddleware.ts
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createStore, applyMiddleware } from 'redux'
+import { createStore } from 'redux'
+import { applyMiddleware } from 'redux-subspace'
 import { take, put } from 'redux-saga/effects'
 import createSagaMiddleware from '../../../src'
 

--- a/packages/redux-subspace-wormhole/test/typescript/definitions-spec.js
+++ b/packages/redux-subspace-wormhole/test/typescript/definitions-spec.js
@@ -23,6 +23,6 @@ describe('TypeScript definitions', function () {
   fs.readdirSync(path.join(__dirname, 'definitions')).forEach((filename) => {
     it(`should compile ${path.basename(filename, path.extname(filename))} against index.d.ts`, (done) => {
       tt.compile([path.join(__dirname, 'definitions', filename)], options, done)
-    }).timeout(5000)
+    }).timeout(20000)
   });
 })

--- a/packages/redux-subspace/src/enhancers/subspaceEnhancer.js
+++ b/packages/redux-subspace/src/enhancers/subspaceEnhancer.js
@@ -8,6 +8,7 @@
 
 import applySubspaceMiddleware from './applySubspaceMiddleware'
 import namespacedAction from '../actions/namespacedAction'
+import applyToChildren from '../middleware/applyToChildren'
 
 const verifyState = (state) => {
     if (process.env.NODE_ENV !== 'production') {
@@ -16,9 +17,9 @@ const verifyState = (state) => {
     return state
 }
 
-const subspaceEnhancer = (mapState, namespace) => applySubspaceMiddleware((store) => ({
+const subspaceEnhancer = (mapState, namespace) => applySubspaceMiddleware(applyToChildren((store) => ({
     getState: (next) => () => verifyState(mapState(next(), store.rootStore.getState())),
     dispatch: (next) => (action) => next(namespacedAction(namespace)(action))
-}))
+})))
 
 export default subspaceEnhancer

--- a/packages/redux-subspace/src/enhancers/subspaceTypesEnhancer.js
+++ b/packages/redux-subspace/src/enhancers/subspaceTypesEnhancer.js
@@ -10,12 +10,12 @@
  export const NAMESPACE_ROOT = 'NAMESPACE_ROOT'
  export const CHILD = 'CHILD'
 
-const subspaceTypesEnhancer = (namespace) => (createSubspace) => (store) => {
+const subspaceTypesEnhancer = (isRoot, namespace) => (createSubspace) => (store) => {
     const subspace = createSubspace(store)
 
     const subspaceTypes = []
 
-    if (!store.subspaceTypes) {
+    if (isRoot) {
         subspaceTypes.push(ROOT)
         subspaceTypes.push(NAMESPACE_ROOT)
     } else if (namespace) {

--- a/packages/redux-subspace/src/store/applyMiddleware.js
+++ b/packages/redux-subspace/src/store/applyMiddleware.js
@@ -6,23 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { compose } from 'redux'
 import applySubspaceMiddleware from '../enhancers/applySubspaceMiddleware'
-import { subspaceEnhanced } from '../store/subspace'
+import { subspaceRoot } from '../store/subspace'
 
 const applyMiddleware = (...middlewares) => (createStore) => (reducer, preloadedState, enhancer) => {
     const store = createStore(reducer, preloadedState, enhancer)
-
-    const subspaceOptions = {
-        enhancer: compose(applySubspaceMiddleware(...middlewares))
-    }
-
-    const rootStore = subspaceEnhanced((state) => state, undefined, subspaceOptions)(store)
-
-    return {
-        ...rootStore,
-        subspaceOptions
-    }
+    return subspaceRoot(store, { enhancer: applySubspaceMiddleware(...middlewares) })
 }
 
 export default applyMiddleware

--- a/packages/redux-subspace/test/enhancers/subspaceEnhancer-spec.js
+++ b/packages/redux-subspace/test/enhancers/subspaceEnhancer-spec.js
@@ -7,19 +7,21 @@
  */
 
 import subspaceEnhancer from '../../src/enhancers/subspaceEnhancer'
+import { NAMESPACE_ROOT, CHILD } from '../../src/enhancers/subspaceTypesEnhancer'
 
 describe('subspaceEnhancer tests', () => {
 
     it('should enhance getState with sub-state', () => {
         const store = { 
             getState: sinon.stub().returns({ parent: { child: { value: 'expected' } }, other: 'value' }),
-            dispatch: sinon.spy(),
+            dispatch: sinon.spy()
         }
 
         const subspace = {
             getState: store.getState,
             dispatch: store.dispatch,
-            rootStore: store
+            rootStore: store,
+            subspaceTypes: [NAMESPACE_ROOT, CHILD]
         }
     
         const createSubspace = sinon.mock().withArgs(store).returns(subspace)
@@ -32,13 +34,14 @@ describe('subspaceEnhancer tests', () => {
     it('should raise error if getState returns undefined', () => {
         const store = { 
             getState: sinon.stub().returns({ parent: { child: { value: 'expected' } } }),
-            dispatch: sinon.spy(),
+            dispatch: sinon.spy()
         }
 
         const subspace = {
             getState: store.getState,
             dispatch: store.dispatch,
-            rootStore: store
+            rootStore: store,
+            subspaceTypes: [NAMESPACE_ROOT, CHILD]
         }
     
         const createSubspace = sinon.mock().withArgs(store).returns(subspace)
@@ -51,13 +54,14 @@ describe('subspaceEnhancer tests', () => {
     it('should not raise error if getState returns undefined in production', () => {
         const store = { 
             getState: sinon.stub().returns({ parent: { child: { value: 'expected' } } }),
-            dispatch: sinon.spy(),
+            dispatch: sinon.spy()
         }
 
         const subspace = {
             getState: store.getState,
             dispatch: store.dispatch,
-            rootStore: store
+            rootStore: store,
+            subspaceTypes: [NAMESPACE_ROOT, CHILD]
         }
     
         const createSubspace = sinon.mock().withArgs(store).returns(subspace)
@@ -79,12 +83,13 @@ describe('subspaceEnhancer tests', () => {
     it('should enhance dispatch with namepace', () => {
         const store = { 
             getState: sinon.stub().returns({ unique: 'value' }),
-            dispatch: sinon.spy(),
+            dispatch: sinon.spy()
         }
 
         const subspace = {
             getState: store.getState,
             dispatch: store.dispatch,
+            subspaceTypes: [NAMESPACE_ROOT, CHILD]
         }
     
         const createSubspace = sinon.mock().withArgs(store).returns(subspace)

--- a/packages/redux-subspace/test/enhancers/subspaceTypesEnhancer-spec.js
+++ b/packages/redux-subspace/test/enhancers/subspaceTypesEnhancer-spec.js
@@ -20,7 +20,7 @@ describe('subspaceTypeEnhancer tests', () => {
     
         const createSubspace = sinon.mock().withArgs(store).returns(subspace)
 
-        const enhancedSubspace = subspaceTypesEnhancer()(createSubspace)(store)
+        const enhancedSubspace = subspaceTypesEnhancer(true)(createSubspace)(store)
 
         expect(enhancedSubspace.getState).to.equal(subspace.getState)
         expect(enhancedSubspace.dispatch).to.equal(subspace.dispatch)
@@ -28,7 +28,7 @@ describe('subspaceTypeEnhancer tests', () => {
     })
 
     it('should enhance child subspace', () => {
-        const store = { unique: 'value', subspaceTypes: 'anything' }
+        const store = { unique: 'value' }
 
         const subspace = {
             getState: sinon.stub().returns({}),
@@ -37,7 +37,7 @@ describe('subspaceTypeEnhancer tests', () => {
     
         const createSubspace = sinon.mock().withArgs(store).returns(subspace)
 
-        const enhancedSubspace = subspaceTypesEnhancer()(createSubspace)(store)
+        const enhancedSubspace = subspaceTypesEnhancer(false)(createSubspace)(store)
 
         expect(enhancedSubspace.getState).to.equal(subspace.getState)
         expect(enhancedSubspace.dispatch).to.equal(subspace.dispatch)
@@ -45,7 +45,7 @@ describe('subspaceTypeEnhancer tests', () => {
     })
 
     it('should enhance namespaced child subspace', () => {
-        const store = { unique: 'value', subspaceTypes: 'anything' }
+        const store = { unique: 'value' }
 
         const subspace = {
             getState: sinon.stub().returns({}),
@@ -54,7 +54,7 @@ describe('subspaceTypeEnhancer tests', () => {
     
         const createSubspace = sinon.mock().withArgs(store).returns(subspace)
 
-        const enhancedSubspace = subspaceTypesEnhancer('test')(createSubspace)(store)
+        const enhancedSubspace = subspaceTypesEnhancer(false, 'test')(createSubspace)(store)
 
         expect(enhancedSubspace.getState).to.equal(subspace.getState)
         expect(enhancedSubspace.dispatch).to.equal(subspace.dispatch)

--- a/packages/redux-subspace/test/store/subspace-spec.js
+++ b/packages/redux-subspace/test/store/subspace-spec.js
@@ -102,20 +102,20 @@ describe('subspace Tests', () => {
 
     it('should provide subspace type on subspace', () => {
         const subspacedStore1 = subspaceRoot(store)
-        const subspacedStore3 = subspace("child2")(subspacedStore1)
-        const subspacedStore4 = subspace(() => {})(subspacedStore1)
-        const subspacedStore5 = subspace(() => {})(subspacedStore3)
-        const subspacedStore6 = subspace('child3')(subspacedStore3)
-        const subspacedStore7 = subspace('child3')(subspacedStore4)
-        const subspacedStore8 = subspace(() => {})(subspacedStore4)
+        const subspacedStore2 = subspace("child")(subspacedStore1)
+        const subspacedStore3 = subspace(() => {})(subspacedStore1)
+        const subspacedStore4 = subspace(() => {})(subspacedStore2)
+        const subspacedStore5 = subspace('child')(subspacedStore2)
+        const subspacedStore6 = subspace('child')(subspacedStore3)
+        const subspacedStore7 = subspace(() => {})(subspacedStore3)
 
         expect(subspacedStore1.subspaceTypes).to.deep.equal([ROOT, NAMESPACE_ROOT])
-        expect(subspacedStore3.subspaceTypes).to.deep.equal([NAMESPACE_ROOT, CHILD])
+        expect(subspacedStore2.subspaceTypes).to.deep.equal([NAMESPACE_ROOT, CHILD])
+        expect(subspacedStore3.subspaceTypes).to.deep.equal([CHILD])
         expect(subspacedStore4.subspaceTypes).to.deep.equal([CHILD])
-        expect(subspacedStore5.subspaceTypes).to.deep.equal([CHILD])
+        expect(subspacedStore5.subspaceTypes).to.deep.equal([NAMESPACE_ROOT, CHILD])
         expect(subspacedStore6.subspaceTypes).to.deep.equal([NAMESPACE_ROOT, CHILD])
-        expect(subspacedStore7.subspaceTypes).to.deep.equal([NAMESPACE_ROOT, CHILD])
-        expect(subspacedStore8.subspaceTypes).to.deep.equal([CHILD])
+        expect(subspacedStore7.subspaceTypes).to.deep.equal([CHILD])
     })
 
     it('should provide root store on subspace', () => {

--- a/packages/redux-subspace/test/store/subspace-spec.js
+++ b/packages/redux-subspace/test/store/subspace-spec.js
@@ -76,13 +76,13 @@ describe('subspace Tests', () => {
             }
         }
 
-        const storeWithMiddleware = { ...store }
-        storeWithMiddleware.dispatch = dispatch
-        storeWithMiddleware.subspaceOptions = {
+        const storeWithEnhancer = { ...store }
+        storeWithEnhancer.dispatch = dispatch
+        storeWithEnhancer.subspaceOptions = {
             enhancer
         }
 
-        const subspacedStore = subspace((state) => state.child, "test")(storeWithMiddleware)
+        const subspacedStore = subspace((state) => state.child, "test")(storeWithEnhancer)
 
         expect(subspacedStore.fromEnhancer).to.be.true
     })
@@ -167,13 +167,8 @@ describe('subspace Tests', () => {
     })
 
     it('should raise error if enhancer is not a function', () => {
-        const storeWithMiddleware = { ...store }
-        storeWithMiddleware.subspaceOptions = {
-            enhancer: 'wrong'
-        }
-
-        expect(() => subspace((state) => state.child, "child")(storeWithMiddleware))
-            .to.throw('enhancer must be a function.')
+        expect(() => subspaceRoot(store, { enhancer: "wrong" })
+            .to.throw('enhancer must be a function.'))
     })
 
     it('should not raise error if enhancer is not a function in production', () => {

--- a/packages/redux-subspace/test/store/subspace-spec.js
+++ b/packages/redux-subspace/test/store/subspace-spec.js
@@ -167,8 +167,8 @@ describe('subspace Tests', () => {
     })
 
     it('should raise error if enhancer is not a function', () => {
-        expect(() => subspaceRoot(store, { enhancer: "wrong" })
-            .to.throw('enhancer must be a function.'))
+        expect(() => subspaceRoot(store, { enhancer: "wrong" }))
+            .to.throw('enhancer must be a function.')
     })
 
     it('should not raise error if enhancer is not a function in production', () => {

--- a/packages/redux-subspace/test/store/subspace-spec.js
+++ b/packages/redux-subspace/test/store/subspace-spec.js
@@ -152,19 +152,19 @@ describe('subspace Tests', () => {
         expect(() => subspace()(store)).to.throw('mapState and/or namespace must be defined.')
     })
 
-    it('should not raise error if neither mapState or namespace are provided in production', () => { 
-        const nodeEnv = process.env.NODE_ENV 
+    it('should not raise error if neither mapState or namespace are provided in production', () => {
+        const nodeEnv = process.env.NODE_ENV
  
-        try { 
-            process.env.NODE_ENV = 'production' 
+        try {
+            process.env.NODE_ENV = 'production'
  
-            const subspacedStore = subspace()(store) 
+            const subspacedStore = subspace()(store)
  
-            expect(subspacedStore).to.not.be.undefined 
-        } finally { 
-            process.env.NODE_ENV = nodeEnv 
-        } 
-    }) 
+            expect(subspacedStore).to.not.be.undefined
+        } finally {
+            process.env.NODE_ENV = nodeEnv
+        }
+    })
 
     it('should raise error if enhancer is not a function', () => {
         const storeWithMiddleware = { ...store }
@@ -176,17 +176,17 @@ describe('subspace Tests', () => {
             .to.throw('enhancer must be a function.')
     })
     
-    it('should not raise error if enhancer is not a function in production', () => { 
-        const nodeEnv = process.env.NODE_ENV 
+    it('should not raise error if enhancer is not a function in production', () => {
+        const nodeEnv = process.env.NODE_ENV
 
-        try { 
-            process.env.NODE_ENV = 'production' 
+        try {
+            process.env.NODE_ENV = 'production'
 
-            const subspacedStore = subspaceRoot(store, { enhancer: "wrong" }) 
+            const subspacedStore = subspaceRoot(store, { enhancer: "wrong" })
 
-            expect(subspacedStore).to.not.be.undefined 
-        } finally { 
-            process.env.NODE_ENV = nodeEnv 
-        } 
-    }) 
+            expect(subspacedStore).to.not.be.undefined
+        } finally {
+            process.env.NODE_ENV = nodeEnv
+        }
+    })
 })

--- a/packages/redux-subspace/test/store/subspace-spec.js
+++ b/packages/redux-subspace/test/store/subspace-spec.js
@@ -154,12 +154,12 @@ describe('subspace Tests', () => {
 
     it('should not raise error if neither mapState or namespace are provided in production', () => {
         const nodeEnv = process.env.NODE_ENV
- 
+
         try {
             process.env.NODE_ENV = 'production'
- 
+
             const subspacedStore = subspace()(store)
- 
+
             expect(subspacedStore).to.not.be.undefined
         } finally {
             process.env.NODE_ENV = nodeEnv
@@ -175,7 +175,7 @@ describe('subspace Tests', () => {
         expect(() => subspace((state) => state.child, "child")(storeWithMiddleware))
             .to.throw('enhancer must be a function.')
     })
-    
+
     it('should not raise error if enhancer is not a function in production', () => {
         const nodeEnv = process.env.NODE_ENV
 

--- a/packages/redux-subspace/test/typescript/definitions-spec.js
+++ b/packages/redux-subspace/test/typescript/definitions-spec.js
@@ -23,6 +23,6 @@ describe('TypeScript definitions', function () {
   fs.readdirSync(path.join(__dirname, 'definitions')).forEach((filename) => {
     it(`should compile ${path.basename(filename, path.extname(filename))} against index.d.ts`, (done) => {
       tt.compile([path.join(__dirname, 'definitions', filename)], options, done)
-    }).timeout(5000)
+    }).timeout(20000)
   });
 })


### PR DESCRIPTION
There is a pretty severe bug with the current alpha version when composing `applyMiddleware` with the [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) that causes an infinite loop when `getState` was called.  

I'm not sure why it only occured when using the extension, and not when using the dev tools directly, like in the real world example, but this change works for both, and when not using dev tools at all.

The change looks more complicated than it really is.  Basically, if the subspace is the root store, don't map the state, or namespace the actions (it was defaulting to `subspace((state) => state, undefined)` anyway).

To achieve this I also had to fix a minor issue when subspaces not created from `applyMiddleware` thought they were the root store if `applyMiddleware` was not used at all.  Most of the noise in this review is caused by fixing that, rather than the actual bug.