### PR TITLE
Improvement to `globalActions` middleware

### DIFF
--- a/packages/redux-subspace/src/index.d.ts
+++ b/packages/redux-subspace/src/index.d.ts
@@ -100,7 +100,7 @@ export function applyToNamespaceRoots(middleware: SubspaceMiddleware | Redux.Mid
 
 export function applyToChildren(middleware: SubspaceMiddleware | Redux.Middleware): SubspaceMiddleware;
 
-export function globalActions(...actionTypes: string[]): SubspaceMiddleware;
+export function globalActions(...actionTypes: (string | RegExp)[]): SubspaceMiddleware;
 
 /**
  * Actions

--- a/packages/redux-subspace/src/middleware/globalActions.js
+++ b/packages/redux-subspace/src/middleware/globalActions.js
@@ -7,9 +7,18 @@
  */
 
 import globalAction from '../actions/globalAction'
+import isGlobal from '../actions/isGlobal'
 
-const globalActions = (...actionTypes) => () => (next) => (action) => action.type && actionTypes.find((type) => action.type.match(type)) 
-    ? next(globalAction(action)) 
-    : next(action)
+const isMatch = (expectedType, actualType) => {
+  return typeof expectedType === 'string' ? actualType === expectedType : actualType.match(expectedType) !== null
+}
+
+const shouldBeGlobal = (action, actionTypes) => {
+  return !isGlobal(action) && actionTypes.find((type) => isMatch(type, action.type))
+}
+
+const globalActions = (...actionTypes) => (store) => (next) => (action) => shouldBeGlobal(action, actionTypes) 
+  ? store.dispatch(globalAction(action)) 
+  : next(action)
 
 export default globalActions

--- a/packages/redux-subspace/test/middleware/globalActions-spec.js
+++ b/packages/redux-subspace/test/middleware/globalActions-spec.js
@@ -92,4 +92,21 @@ describe('globalActions tests', () => {
         expect(next).to.be.calledWith(action)
         expect(store.dispatch).to.not.be.called
     })
+
+    it('should ignore already global actions', () => {
+        const store = {
+            dispatch: sinon.spy()
+        }
+
+        const next = sinon.spy()
+
+        const middleware = globalActions('TEST')(store)(next)
+
+        const action = () => ({ type: 'TEST', value: 'expected', globalAction: true })
+
+        middleware(action)
+
+        expect(next).to.be.calledWith(action)
+        expect(store.dispatch).to.not.be.called
+    })
 })

--- a/packages/redux-subspace/test/middleware/globalActions-spec.js
+++ b/packages/redux-subspace/test/middleware/globalActions-spec.js
@@ -66,11 +66,13 @@ describe('globalActions tests', () => {
 
         const next = sinon.spy()
 
-        const middleware = globalActions('TEST')(store)(next)
+        const middleware = globalActions('A_TEST')(store)(next)
 
-        middleware({ type: 'NOT_TEST', value: 'expected' })
+        middleware({ type: 'NOT_A_TEST', value: 'expected' })
+        middleware({ type: 'TEST', value: 'expected' })
 
-        expect(next).to.be.calledWithMatch({ type: 'NOT_TEST', value: 'expected' })
+        expect(next).to.be.calledWithMatch({ type: 'NOT_A_TEST', value: 'expected' })
+        expect(next).to.be.calledWithMatch({ type: 'TEST', value: 'expected' })
         expect(store.dispatch).to.not.be.called
     })
 

--- a/packages/redux-subspace/test/middleware/globalActions-spec.js
+++ b/packages/redux-subspace/test/middleware/globalActions-spec.js
@@ -10,60 +10,84 @@ import globalActions from '../../src/middleware/globalActions'
 
 describe('globalActions tests', () => {
     it('should make action global', () => {
+        const store = {
+            dispatch: sinon.spy()
+        }
+
         const next = sinon.spy()
 
-        const middleware = globalActions('TEST')()(next)
+        const middleware = globalActions('TEST')(store)(next)
 
         middleware({ type: 'TEST', value: 'expected' })
 
-        expect(next).to.be.calledWithMatch({ type: 'TEST', value: 'expected', globalAction: true })
+        expect(store.dispatch).to.be.calledWithMatch({ type: 'TEST', value: 'expected', globalAction: true })
+        expect(next).to.not.be.called
     })
 
     it('should make actions global', () => {
+        const store = {
+            dispatch: sinon.spy()
+        }
+
         const next = sinon.spy()
 
-        const middleware = globalActions('TEST_1', 'TEST_2')()(next)
+        const middleware = globalActions('TEST_1', 'TEST_2')(store)(next)
 
         middleware({ type: 'TEST_1', value: 'expected 1' })
         middleware({ type: 'TEST_2', value: 'expected 2' })
 
-        expect(next).to.be.calledWithMatch({ type: 'TEST_1', value: 'expected 1', globalAction: true })
-        expect(next).to.be.calledWithMatch({ type: 'TEST_2', value: 'expected 2', globalAction: true })
+        expect(store.dispatch).to.be.calledWithMatch({ type: 'TEST_1', value: 'expected 1', globalAction: true })
+        expect(store.dispatch).to.be.calledWithMatch({ type: 'TEST_2', value: 'expected 2', globalAction: true })
+        expect(next).to.not.be.called
     })
 
     it('should match regex', () => {
+        const store = {
+            dispatch: sinon.spy()
+        }
+
         const next = sinon.spy()
 
-        const middleware = globalActions(/TEST_.*/)()(next)
+        const middleware = globalActions(/TEST_.*/)(store)(next)
 
         middleware({ type: 'TEST_1', value: 'expected 1' })
         middleware({ type: 'TEST_2', value: 'expected 2' })
         middleware({ type: 'TEST', value: 'expected' })
 
-        expect(next).to.be.calledWithMatch({ type: 'TEST_1', value: 'expected 1', globalAction: true })
-        expect(next).to.be.calledWithMatch({ type: 'TEST_2', value: 'expected 2', globalAction: true })
+        expect(store.dispatch).to.be.calledWithMatch({ type: 'TEST_1', value: 'expected 1', globalAction: true })
+        expect(store.dispatch).to.be.calledWithMatch({ type: 'TEST_2', value: 'expected 2', globalAction: true })
         expect(next).to.be.calledWithMatch({ type: 'TEST', value: 'expected' })
     })
 
-    it('should ignore actions with differnt action type', () => {
+    it('should ignore actions with different action type', () => {
+        const store = {
+            dispatch: sinon.spy()
+        }
+
         const next = sinon.spy()
 
-        const middleware = globalActions('TEST')()(next)
+        const middleware = globalActions('TEST')(store)(next)
 
         middleware({ type: 'NOT_TEST', value: 'expected' })
 
         expect(next).to.be.calledWithMatch({ type: 'NOT_TEST', value: 'expected' })
+        expect(store.dispatch).to.not.be.called
     })
 
     it('should ignore actions without a type', () => {
+        const store = {
+            dispatch: sinon.spy()
+        }
+
         const next = sinon.spy()
 
-        const middleware = globalActions('TEST')()(next)
+        const middleware = globalActions('TEST')(store)(next)
 
         const action = () => ({ type: 'TEST', value: 'expected' })
 
         middleware(action)
 
         expect(next).to.be.calledWith(action)
+        expect(store.dispatch).to.not.be.called
     })
 })

--- a/packages/redux-subspace/test/typescript/definitions/globalActions.ts
+++ b/packages/redux-subspace/test/typescript/definitions/globalActions.ts
@@ -11,3 +11,9 @@ import { applyMiddleware, globalActions } from '../../../src'
 applyMiddleware(globalActions('test'))
 
 applyMiddleware(globalActions('test1', 'test2'))
+
+applyMiddleware(globalActions(/test/))
+
+applyMiddleware(globalActions(/test1/, /test2/))
+
+applyMiddleware(globalActions('test1', /test2/))


### PR DESCRIPTION
Currently, the `globalActions` middleware would make the action global and pass it on to the next handler in the `dispatch` chain.  This change makes it so that the now global action is dispatched through the whole chain and ignored by the `globalActions` middleware if it has already been made global.

This also fixes and issue where the action type matching was potentially matching incorrect action types, if the global action type was a substring of the action's type.

Finally, the typescript definition has been updated to also allow regex to be passed the `globalActions`.