### PR TITLE
[react-redux-subspace] Add string to prop types of mapState prop

### DIFF
--- a/packages/react-redux-subspace/src/components/SubspaceProvider.js
+++ b/packages/react-redux-subspace/src/components/SubspaceProvider.js
@@ -27,7 +27,10 @@ class SubspaceProvider extends React.PureComponent {
 
 SubspaceProvider.propTypes = {
     children: PropTypes.element.isRequired,
-    mapState: PropTypes.func,
+    mapState: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.string,
+    ]),
     namespace: PropTypes.string,
     subspaceDecorator: PropTypes.func,
 }


### PR DESCRIPTION
According to the docs `mapState` may receive a string, but when I use `<SubspaceProvider mapState="someString" />` React throws a warning about invalid prop type.

This PR extends prop types for the `<SubspaceProvider>` component to expect either string or function.