### PR TITLE
Pass redux-saga context through to subspaced sagas

### DIFF
--- a/packages/redux-subspace-saga/docs/api/provideStore.md
+++ b/packages/redux-subspace-saga/docs/api/provideStore.md
@@ -6,6 +6,8 @@ A higher-order saga that injects the provided store into the saga's context.
 
 1. `store` (_Object_): An object that conforms to the [Redux store API](http://redux.js.org/docs/api/Store.html). Generally, this will be the root Redux store of the application, but it could also be a subspace if required.
 
+2. `options` (_Object_): The [saga middleware options](https://redux-saga.js.org/docs/api/#runsagaoptions-saga-args) to pass to use when running subpsaced sagas.
+
 ## Returns
 
 (_Function_): A function that accepts a saga (generator function) and returns a new saga that injects the store into the saga's context before executing the orignal saga.

--- a/packages/redux-subspace-saga/src/middleware/createSagaMiddleware.js
+++ b/packages/redux-subspace-saga/src/middleware/createSagaMiddleware.js
@@ -13,7 +13,7 @@ export default (options) => {
     const sagaMiddleware = createSagaMiddleware(options)
     
     const sagaSubspaceMiddleware = (store) => {
-        sagaSubspaceMiddleware.run = (saga) => sagaMiddleware.run(provideStore(store)(saga))
+        sagaSubspaceMiddleware.run = (saga, ...args) => sagaMiddleware.run(provideStore(store, options)(saga), ...args)
         return sagaMiddleware(store)
     }
 

--- a/packages/redux-subspace-saga/src/sagas/provideStore.js
+++ b/packages/redux-subspace-saga/src/sagas/provideStore.js
@@ -8,9 +8,10 @@
 
 import { setContext } from 'redux-saga/effects'
 
-const provideStore = (store) => (saga) => {
+const provideStore = (store, options) => (saga) => {
     return function* () {
         yield setContext({ store })
+        yield setContext({ sagaMiddlewareOptions: options })
         yield* saga()
     }
 }

--- a/packages/redux-subspace-saga/src/sagas/subspaced.js
+++ b/packages/redux-subspace-saga/src/sagas/subspaced.js
@@ -39,17 +39,19 @@ const subspaced = (mapState, namespace) => {
     const subspaceDecorator = subspace(mapState, namespace)
 
     return (saga) => {
-        return function* wrappedSaga() {
+        return function* wrappedSaga(...args) {
             const parentStore = yield getContext('store')
+            const sagaMiddlewareOptions = yield getContext('sagaMiddlewareOptions')
 
             const sagaEmitter = emitter()
             
             const store = {
+                ...sagaMiddlewareOptions,
                 ...subspaceDecorator(parentStore),
                 subscribe: sagaEmitter.subscribe,
             }
 
-            runSaga(store, provideStore(store)(saga))
+            runSaga(store, provideStore(store, sagaMiddlewareOptions)(saga), ...args)
 
             yield takeEvery('*', function* (action) {
                 store.processAction(action, sagaEmitter.emit)

--- a/packages/redux-subspace-saga/test/integration-spec.js
+++ b/packages/redux-subspace-saga/test/integration-spec.js
@@ -8,7 +8,7 @@
 
 import { createStore, combineReducers } from 'redux'
 import { subspace, applyMiddleware, namespaced } from 'redux-subspace'
-import { takeEvery, select, put, all } from 'redux-saga/effects'
+import { takeEvery, select, put, all, getContext } from 'redux-saga/effects'
 import createSagaMiddleware, { subspaced } from '../src'
 
 describe('integration tests', () => {
@@ -32,6 +32,124 @@ describe('integration tests', () => {
             yield takeEvery(TEST_ACTION_TRIGGER, makeTestAction)
         }
     }
+
+    const contextAwareSaga = () => {
+        function* makeTestAction(action) {
+            const value = yield getContext(action.key)
+            yield put({ type: TEST_ACTION, value: value })
+        }
+        return function* watchTestAction() {
+            yield takeEvery(TEST_ACTION_TRIGGER, makeTestAction)
+        }
+    }
+
+    it('should transfer context to subspaced saga', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent1)(rootStore)
+
+        const parentSaga = subspaced((state) => state.parent1)(contextAwareSaga())
+
+        sagaMiddleware.run(parentSaga)
+
+        parentStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'context value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should transfer context to nested subspaced saga', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent1)(rootStore)
+
+        const childStore = subspace((state) => state.child1)(parentStore)
+
+        const childSaga = subspaced((state) => state.child1)(contextAwareSaga())
+
+        const parentSaga = subspaced((state) => state.parent1)(childSaga)
+
+        sagaMiddleware.run(parentSaga)
+
+        childStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'context value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should transfer context to subspaced saga with namespace', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
+
+        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(contextAwareSaga())
+
+        sagaMiddleware.run(parentSaga)
+
+        parentStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'initial value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'context value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should transfer context to nested subspaced saga with namespace', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
+
+        const childStore = subspace((state) => state.child2, 'childNamespace')(parentStore)
+
+        const childSaga = subspaced((state) => state.child2, 'childNamespace')(contextAwareSaga())
+
+        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(childSaga)
+
+        sagaMiddleware.run(parentSaga)
+
+        childStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'initial value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'context value'
+            }
+        })
+    })
 
     it('should work with no subspaces', () => {
         const sagaMiddleware = createSagaMiddleware()

--- a/packages/redux-subspace-saga/test/sagas/provideStore-spec.js
+++ b/packages/redux-subspace-saga/test/sagas/provideStore-spec.js
@@ -23,6 +23,28 @@ describe('provideStore Tests', () => {
         const iterator = sagaWithStore()
 
         expect(iterator.next().value).to.deep.equal(setContext({ store }))
+        expect(iterator.next().value).to.deep.equal(setContext({ sagaMiddlewareOptions: undefined }))
+        expect(iterator.next().value).to.deep.equal(take("TEST"))
+        expect(iterator.next({ type: "TEST" }).value).to.deep.equal(put({ type: "USE_TEST" }))
+        expect(iterator.next().done).to.be.true
+    })
+
+
+    it('should provide store and options to saga', () => {
+        const store = { getState: "getState", dispatch: "dispatch" }
+        const options = { context: { value: "test" }}
+
+        function* saga() {
+            yield take("TEST")
+            yield put({ type: "USE_TEST" })
+        }
+
+        const sagaWithStore = provideStore(store, options)(saga)
+
+        const iterator = sagaWithStore()
+
+        expect(iterator.next().value).to.deep.equal(setContext({ store }))
+        expect(iterator.next().value).to.deep.equal(setContext({ sagaMiddlewareOptions: options }))
         expect(iterator.next().value).to.deep.equal(take("TEST"))
         expect(iterator.next({ type: "TEST" }).value).to.deep.equal(put({ type: "USE_TEST" }))
         expect(iterator.next().done).to.be.true

--- a/packages/redux-subspace-saga/test/sagas/subspaced-spec.js
+++ b/packages/redux-subspace-saga/test/sagas/subspaced-spec.js
@@ -34,7 +34,8 @@ describe('subspaced Tests', () => {
         const iterator = subspacedSaga()
 
         expect(iterator.next().value).to.deep.equal(getContext('store'))
-        iterator.next(mockStore)
+        expect(iterator.next(mockStore).value).to.deep.equal(getContext('sagaMiddlewareOptions'))
+        expect(iterator.next(undefined).value).to.be.ok
         expect(iterator.next({ type: "TEST" }).done).to.be.true
 
         expect(mockStore.getActions()).to.deep.equal([{ type: "SET_VALUE", value: "expected" }])
@@ -61,7 +62,8 @@ describe('subspaced Tests', () => {
         const iterator = subspacedSaga()
 
         expect(iterator.next().value).to.deep.equal(getContext('store'))
-        iterator.next(mockStore)
+        expect(iterator.next(mockStore).value).to.deep.equal(getContext('sagaMiddlewareOptions'))
+        expect(iterator.next(undefined).value).to.be.ok
         expect(iterator.next({ type: "test/TEST" }).done).to.be.true
 
         expect(mockStore.getActions()).to.deep.equal([{ type: "test/SET_VALUE", value: "expected" }])
@@ -88,7 +90,8 @@ describe('subspaced Tests', () => {
         const iterator = subspacedSaga()
 
         expect(iterator.next().value).to.deep.equal(getContext('store'))
-        iterator.next(mockStore)
+        expect(iterator.next(mockStore).value).to.deep.equal(getContext('sagaMiddlewareOptions'))
+        expect(iterator.next(undefined).value).to.be.ok
         expect(iterator.next({ type: "TEST" }).done).to.be.true
 
         expect(mockStore.getActions()).to.deep.equal([{ type: "subState/SET_VALUE", value: "expected" }])
@@ -115,7 +118,8 @@ describe('subspaced Tests', () => {
         const iterator = subspacedSaga()
 
         expect(iterator.next().value).to.deep.equal(getContext('store'))
-        iterator.next(mockStore)
+        expect(iterator.next(mockStore).value).to.deep.equal(getContext('sagaMiddlewareOptions'))
+        expect(iterator.next(undefined).value).to.be.ok
         expect(iterator.next(globalAction({ type: "TEST" })).done).to.be.true
 
         expect(mockStore.getActions()).to.deep.equal([{ type: "test/SET_VALUE", value: "expected" }])
@@ -142,9 +146,38 @@ describe('subspaced Tests', () => {
         const iterator = subspacedSaga()
 
         expect(iterator.next().value).to.deep.equal(getContext('store'))
-        iterator.next(mockStore)
+        expect(iterator.next(mockStore).value).to.deep.equal(getContext('sagaMiddlewareOptions'))
+        expect(iterator.next(undefined).value).to.be.ok
         expect(iterator.next({ type: "test/TEST" }).done).to.be.true
 
         expect(mockStore.getActions()).to.deep.equal([globalAction({ type: "SET_VALUE", value: "expected" })])
+    })
+
+    it('should get context for subspaced saga', () => {
+
+        const state = {
+            subState: {
+                value: "also wrong"
+            },
+            value: "wrong"
+        }
+
+        const mockStore = configureStore()(state)
+
+        function* saga() {
+            const value = yield getContext('value')
+            yield put({ type: "SET_VALUE", value })
+        }
+
+        const subspacedSaga = subspaced(state => state.subState)(saga)
+
+        const iterator = subspacedSaga()
+
+        expect(iterator.next().value).to.deep.equal(getContext('store'))
+        expect(iterator.next(mockStore).value).to.deep.equal(getContext('sagaMiddlewareOptions'))
+        expect(iterator.next({ context: { value: 'expected' } }).value).to.be.ok
+        expect(iterator.next({ type: "TEST" }).done).to.be.true
+
+        expect(mockStore.getActions()).to.deep.equal([{ type: "SET_VALUE", value: "expected" }])
     })
 })


### PR DESCRIPTION
redux-saga context is not being passed through to subspaced sagas as they run in a different saga runtime to the root store middleware.

This change will pass on any  context provided during middlware creation so that the subspaced saga has access to it as well.

There is a caveat that context provided by the [`setContext` effect](https://redux-saga.js.org/docs/api/#setcontextprops) will not be preserved due to a limitation in how context is accessed within sagas.  There is a [redux-saga issue](https://github.com/redux-saga/redux-saga/issues/1280) to hopefully get around then, but until then, we are restricted in what we can provide.  I have documented this in the `redux-subspace-saga` usage docs.