### PR TITLE
Pass saga args through to subspaced sagas

### DIFF
--- a/packages/redux-subspace-saga/package.json
+++ b/packages/redux-subspace-saga/package.json
@@ -27,7 +27,7 @@
     "redux-subspace": "^2.1.0"
   },
   "peerDependencies": {
-    "redux-saga": "^0.15.0"
+    "redux-saga": "^0.16.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/packages/redux-subspace-saga/src/sagas/provideStore.js
+++ b/packages/redux-subspace-saga/src/sagas/provideStore.js
@@ -8,12 +8,11 @@
 
 import { setContext } from 'redux-saga/effects'
 
-const provideStore = (store, options) => (saga) => {
-    return function* () {
-        yield setContext({ store })
-        yield setContext({ sagaMiddlewareOptions: options })
-        yield* saga()
-    }
+const provideStore = (store, options) => saga => {
+  return function*(...args) {
+    yield setContext({ store, sagaMiddlewareOptions: options })
+    yield* saga(...args)
+  }
 }
 
 export default provideStore

--- a/packages/redux-subspace-saga/test/integration-spec.js
+++ b/packages/redux-subspace-saga/test/integration-spec.js
@@ -43,113 +43,9 @@ describe('integration tests', () => {
         }
     }
 
-    it('should transfer context to subspaced saga', () => {
-        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
-
-        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
-
-        const parentStore = subspace((state) => state.parent1)(rootStore)
-
-        const parentSaga = subspaced((state) => state.parent1)(contextAwareSaga())
-
-        sagaMiddleware.run(parentSaga)
-
-        parentStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
-
-        expect(rootStore.getState()).to.deep.equal({
-            parent1: {
-                child1: 'context value',
-                child2: 'initial value'
-            },
-            parent2: {
-                child1: 'initial value',
-                child2: 'initial value'
-            }
-        })
-    })
-
-    it('should transfer context to nested subspaced saga', () => {
-        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
-
-        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
-
-        const parentStore = subspace((state) => state.parent1)(rootStore)
-
-        const childStore = subspace((state) => state.child1)(parentStore)
-
-        const childSaga = subspaced((state) => state.child1)(contextAwareSaga())
-
-        const parentSaga = subspaced((state) => state.parent1)(childSaga)
-
-        sagaMiddleware.run(parentSaga)
-
-        childStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
-
-        expect(rootStore.getState()).to.deep.equal({
-            parent1: {
-                child1: 'context value',
-                child2: 'initial value'
-            },
-            parent2: {
-                child1: 'initial value',
-                child2: 'initial value'
-            }
-        })
-    })
-
-    it('should transfer context to subspaced saga with namespace', () => {
-        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
-
-        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
-
-        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
-
-        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(contextAwareSaga())
-
-        sagaMiddleware.run(parentSaga)
-
-        parentStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
-
-        expect(rootStore.getState()).to.deep.equal({
-            parent1: {
-                child1: 'initial value',
-                child2: 'initial value'
-            },
-            parent2: {
-                child1: 'context value',
-                child2: 'initial value'
-            }
-        })
-    })
-
-    it('should transfer context to nested subspaced saga with namespace', () => {
-        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
-
-        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
-
-        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
-
-        const childStore = subspace((state) => state.child2, 'childNamespace')(parentStore)
-
-        const childSaga = subspaced((state) => state.child2, 'childNamespace')(contextAwareSaga())
-
-        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(childSaga)
-
-        sagaMiddleware.run(parentSaga)
-
-        childStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
-
-        expect(rootStore.getState()).to.deep.equal({
-            parent1: {
-                child1: 'initial value',
-                child2: 'initial value'
-            },
-            parent2: {
-                child1: 'initial value',
-                child2: 'context value'
-            }
-        })
-    })
+    function* sagaWithArgs(value) {
+        yield put({ type: TEST_ACTION, value: value })
+    }
 
     it('should work with no subspaces', () => {
         const sagaMiddleware = createSagaMiddleware()
@@ -363,6 +259,202 @@ describe('integration tests', () => {
             parent2: {
                 child1: 'parent value',
                 child2: 'child value'
+            }
+        })
+    })
+
+    it('should transfer context to subspaced saga', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent1)(rootStore)
+
+        const parentSaga = subspaced((state) => state.parent1)(contextAwareSaga())
+
+        sagaMiddleware.run(parentSaga)
+
+        parentStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'context value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should transfer context to nested subspaced saga', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent1)(rootStore)
+
+        const childStore = subspace((state) => state.child1)(parentStore)
+
+        const childSaga = subspaced((state) => state.child1)(contextAwareSaga())
+
+        const parentSaga = subspaced((state) => state.parent1)(childSaga)
+
+        sagaMiddleware.run(parentSaga)
+
+        childStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'context value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should transfer context to subspaced saga with namespace', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
+
+        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(contextAwareSaga())
+
+        sagaMiddleware.run(parentSaga)
+
+        parentStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'initial value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'context value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should transfer context to nested subspaced saga with namespace', () => {
+        const sagaMiddleware = createSagaMiddleware({ context: { fromContext: 'context value'} })
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentStore = subspace((state) => state.parent2, 'parentNamespace')(rootStore)
+
+        const childStore = subspace((state) => state.child2, 'childNamespace')(parentStore)
+
+        const childSaga = subspaced((state) => state.child2, 'childNamespace')(contextAwareSaga())
+
+        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(childSaga)
+
+        sagaMiddleware.run(parentSaga)
+
+        childStore.dispatch({ type: TEST_ACTION_TRIGGER, key: 'fromContext' })
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'initial value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'context value'
+            }
+        })
+    })
+
+    it('should pass args through to subspaced saga', () => {
+        const sagaMiddleware = createSagaMiddleware()
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentSaga = subspaced((state) => state.parent1)(sagaWithArgs)
+
+        sagaMiddleware.run(parentSaga, 'args value')
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'args value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should pass args through to nested subspaced saga', () => {
+        const sagaMiddleware = createSagaMiddleware()
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const childSaga = subspaced((state) => state.child1)(sagaWithArgs)
+
+        const parentSaga = subspaced((state) => state.parent1)(childSaga)
+
+        sagaMiddleware.run(parentSaga, 'args value')
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'args value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should pass args through to subspaced saga with namespace', () => {
+        const sagaMiddleware = createSagaMiddleware()
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(sagaWithArgs)
+
+        sagaMiddleware.run(parentSaga, 'args value')
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'initial value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'args value',
+                child2: 'initial value'
+            }
+        })
+    })
+
+    it('should pass args through to nested subspaced saga with namespace', () => {
+        const sagaMiddleware = createSagaMiddleware()
+
+        const rootStore = createStore(rootReducer, applyMiddleware(sagaMiddleware))
+
+        const childSaga = subspaced((state) => state.child2, 'childNamespace')(sagaWithArgs)
+
+        const parentSaga = subspaced((state) => state.parent2, 'parentNamespace')(childSaga)
+
+        sagaMiddleware.run(parentSaga, 'args value')
+
+        expect(rootStore.getState()).to.deep.equal({
+            parent1: {
+                child1: 'initial value',
+                child2: 'initial value'
+            },
+            parent2: {
+                child1: 'initial value',
+                child2: 'args value'
             }
         })
     })

--- a/packages/redux-subspace-saga/test/sagas/provideStore-spec.js
+++ b/packages/redux-subspace-saga/test/sagas/provideStore-spec.js
@@ -22,8 +22,7 @@ describe('provideStore Tests', () => {
 
         const iterator = sagaWithStore()
 
-        expect(iterator.next().value).to.deep.equal(setContext({ store }))
-        expect(iterator.next().value).to.deep.equal(setContext({ sagaMiddlewareOptions: undefined }))
+        expect(iterator.next().value).to.deep.equal(setContext({ store, sagaMiddlewareOptions: undefined }))
         expect(iterator.next().value).to.deep.equal(take("TEST"))
         expect(iterator.next({ type: "TEST" }).value).to.deep.equal(put({ type: "USE_TEST" }))
         expect(iterator.next().done).to.be.true
@@ -43,8 +42,7 @@ describe('provideStore Tests', () => {
 
         const iterator = sagaWithStore()
 
-        expect(iterator.next().value).to.deep.equal(setContext({ store }))
-        expect(iterator.next().value).to.deep.equal(setContext({ sagaMiddlewareOptions: options }))
+        expect(iterator.next().value).to.deep.equal(setContext({ store, sagaMiddlewareOptions: options }))
         expect(iterator.next().value).to.deep.equal(take("TEST"))
         expect(iterator.next({ type: "TEST" }).value).to.deep.equal(put({ type: "USE_TEST" }))
         expect(iterator.next().done).to.be.true


### PR DESCRIPTION
redux-saga supports [passing arguments to sagas when running them](https://redux-saga.js.org/docs/api/#middlewarerunsaga-args).  Although `createSagaMiddleware` does pass the args on when to the underlying `run` call, the `subspaced` and `provideStore` higher-order sagas would not pass them through to the sagas they were wrapping.