### PR TITLE
middleware api now includes all subspace values so root enhancer can be applied in middleware

### DIFF
--- a/packages/redux-subspace-saga/package-lock.json
+++ b/packages/redux-subspace-saga/package-lock.json
@@ -4769,6 +4769,11 @@
 			"resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.0.tgz",
 			"integrity": "sha1-CiMdsKFIkwHdmA9vL4jYztQY9yQ="
 		},
+		"redux-thunk": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
+			"integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",

--- a/packages/redux-subspace-saga/package.json
+++ b/packages/redux-subspace-saga/package.json
@@ -46,6 +46,7 @@
     "redux": "^3.6.0",
     "redux-mock-store": "^1.3.0",
     "redux-saga": "^0.16.0",
+    "redux-thunk": "^2.2.0",
     "sinon": "^4.0.2",
     "sinon-chai": "^2.14.0",
     "typescript": "^2.5.3",

--- a/packages/redux-subspace/src/enhancers/applySubspaceMiddleware.js
+++ b/packages/redux-subspace/src/enhancers/applySubspaceMiddleware.js
@@ -12,18 +12,12 @@ const applySubspaceMiddleware = (...middlewares) => (createSubspace) => (store) 
 
     const subspacedStore = createSubspace(store)
 
-    let getState = subspacedStore.getState
-    let dispatch = subspacedStore.dispatch
-
-    const { namespace, rootStore, subspaceTypes, processAction } = subspacedStore
+    let { getState, dispatch, subscribe, replaceReducer, ...subspaceValues } = subspacedStore
 
     const middlewareApi = {
         getState: (...args) => getState(...args),
         dispatch: (...args) => dispatch(...args),
-        rootStore,
-        namespace,
-        subspaceTypes,
-        processAction
+        ...subspaceValues
     }
 
     const chain = middlewares.map((middleware) => middleware(middlewareApi))

--- a/packages/redux-subspace/src/index.d.ts
+++ b/packages/redux-subspace/src/index.d.ts
@@ -30,11 +30,16 @@ export interface ProcessAction {
     <TReturn>(action: Redux.Action, callback: ProcessActionCallback<TReturn>, defaultValue: TReturn): TReturn;
 }
 
+export interface SubspaceOptions {
+    enhancer: Redux.GenericStoreEnhancer
+}
+
 export interface Subspace<TState, TRootState> extends Redux.Store<TState> {
     rootStore: Redux.Store<TRootState>;
     namespace: string;
     subspaceTypes: SubspaceType[];
     processAction: ProcessAction;
+    subspaceOptions: SubspaceOptions;
 }
 
 export interface StoreDecorator<TParentState, TState, TStore extends Redux.Store<TState>> {
@@ -86,6 +91,7 @@ export interface SubspaceMiddlewareAPI<TState, TRootState> {
     namespace: string;
     subspaceTypes: SubspaceType[];
     processAction: ProcessAction;
+    subspaceOptions: SubspaceOptions;
 }
 
 export interface SubspaceMiddleware {


### PR DESCRIPTION
subspaceOptions (which has the root enhancer) was not being passed through to the middleware API. Any subspaces created in middleware were not correctly applying the middleware chain.

I felt it's safer to to exclude the parts of the subspacedStore we don't want, to avoid issues like this in the future (we have to be careful to remember to update the typescript definitions).