### PR TITLE
Annotate pure calls with babel plugin to slightly improve tree-shakea…

### DIFF
--- a/packages/react-redux-subspace/.babelrc.js
+++ b/packages/react-redux-subspace/.babelrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'stage-3',
   ],
   plugins: [
+    'annotate-pure-calls',
     cjs && 'transform-es2015-modules-commonjs',
   ].filter(Boolean),
 }

--- a/packages/react-redux-subspace/package-lock.json
+++ b/packages/react-redux-subspace/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "react-redux-subspace",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
 			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.40"
 			}
@@ -14,6 +17,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
 			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40",
 				"jsesc": "2.5.1",
@@ -25,7 +29,8 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"dev": true
 				}
 			}
 		},
@@ -33,6 +38,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
 			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.40",
 				"@babel/template": "7.0.0-beta.40",
@@ -43,6 +49,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
 			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40"
 			}
@@ -51,6 +58,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -61,6 +69,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -69,6 +78,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -79,6 +89,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -89,6 +100,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
 			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/types": "7.0.0-beta.40",
@@ -99,7 +111,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -107,6 +120,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
 			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/generator": "7.0.0-beta.40",
@@ -122,7 +136,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -143,6 +158,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
 			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -160,6 +176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
 			"requires": {
 				"samsam": "1.3.0"
 			}
@@ -167,7 +184,8 @@
 		"@types/node": {
 			"version": "9.4.6",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-			"integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
+			"integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+			"dev": true
 		},
 		"@types/react": {
 			"version": "16.0.40",
@@ -177,17 +195,20 @@
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+			"dev": true
 		},
 		"acorn": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
+			"dev": true
 		},
 		"acorn-globals": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.5.1"
 			}
@@ -196,6 +217,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -203,7 +225,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -211,6 +234,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.1.0",
@@ -221,27 +245,32 @@
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"micromatch": "2.3.11",
@@ -252,6 +281,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -260,6 +290,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
@@ -269,17 +300,20 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
 			"optional": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0"
@@ -289,6 +323,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -296,18 +331,21 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true,
 			"optional": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -317,48 +355,57 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
 		},
 		"babel-cli": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-polyfill": "6.26.0",
@@ -381,6 +428,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -391,6 +439,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -417,6 +466,7 @@
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/traverse": "7.0.0-beta.40",
@@ -429,7 +479,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -437,6 +488,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -452,6 +504,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -462,6 +515,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -472,6 +526,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -483,6 +538,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -494,6 +550,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -504,6 +561,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -516,6 +574,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -525,6 +584,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -534,6 +594,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -543,6 +604,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -553,6 +615,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -565,6 +628,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -578,6 +642,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -587,14 +652,25 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-annotate-pure-calls": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz",
+			"integrity": "sha512-0IP5H7eRCKPKcas8JCJf11c6OrSNmYmc3Ehaz+JFLasa4a2pLvfnfOeMBYMdqmutXjXcoqWA+H7ZyzHo008S/w==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -603,6 +679,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -610,42 +687,56 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -656,6 +747,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -666,6 +758,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -674,6 +767,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -682,6 +776,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0",
@@ -694,6 +789,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
@@ -710,6 +806,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -719,6 +816,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -727,6 +825,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -736,6 +835,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -744,6 +844,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -754,6 +855,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -762,6 +864,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -772,6 +875,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -783,6 +887,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -793,6 +898,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -803,6 +909,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.26.0"
@@ -812,6 +919,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -825,6 +933,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -834,6 +943,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -842,6 +952,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -852,6 +963,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -860,6 +972,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -868,6 +981,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -878,6 +992,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -888,6 +1003,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -897,6 +1013,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -906,6 +1023,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -914,6 +1032,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -924,6 +1043,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -933,6 +1053,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -942,6 +1063,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.10.1"
 			}
@@ -950,6 +1072,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -959,6 +1082,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"core-js": "2.5.3",
@@ -968,7 +1092,8 @@
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -976,6 +1101,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -1013,6 +1139,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -1021,6 +1148,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -1034,6 +1162,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -1046,6 +1175,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -1060,6 +1190,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.5.3",
 				"regenerator-runtime": "0.11.1"
@@ -1069,6 +1200,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1081,6 +1213,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1097,6 +1230,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1107,17 +1241,20 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
@@ -1127,17 +1264,20 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+			"dev": true
 		},
 		"boom": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"dev": true,
 			"requires": {
 				"hoek": "4.2.1"
 			}
@@ -1146,6 +1286,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1155,6 +1296,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
@@ -1165,17 +1307,20 @@
 		"browser-process-hrtime": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+			"dev": true
 		},
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
 		},
 		"browserslist": {
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000813",
 				"electron-to-chromium": "1.3.36"
@@ -1185,6 +1330,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1192,22 +1338,26 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000813",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz",
-			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
+			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A==",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"check-error": "1.0.2",
@@ -1221,6 +1371,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1237,17 +1388,20 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.2",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
 			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+			"dev": true,
 			"requires": {
 				"css-select": "1.2.0",
 				"dom-serializer": "0.1.0",
@@ -1261,6 +1415,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
@@ -1277,12 +1432,14 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
 			}
@@ -1290,17 +1447,20 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1308,17 +1468,20 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"colors": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -1326,17 +1489,20 @@
 		"commander": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5",
@@ -1346,27 +1512,32 @@
 		"content-type-parser": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-env": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.3.tgz",
 			"integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"is-windows": "1.0.2"
@@ -1376,6 +1547,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -1386,6 +1558,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"dev": true,
 			"requires": {
 				"boom": "5.2.0"
 			},
@@ -1394,6 +1567,7 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"dev": true,
 					"requires": {
 						"hoek": "4.2.1"
 					}
@@ -1404,6 +1578,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"dev": true,
 			"requires": {
 				"boolbase": "1.0.0",
 				"css-what": "2.1.0",
@@ -1414,17 +1589,20 @@
 		"css-what": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+			"dev": true
 		},
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"dev": true
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"dev": true,
 			"requires": {
 				"cssom": "0.3.2"
 			}
@@ -1433,6 +1611,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -1441,6 +1620,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1449,6 +1629,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1456,12 +1637,14 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1471,6 +1654,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1484,12 +1668,14 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1497,17 +1683,20 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true
 		},
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
 			}
@@ -1516,6 +1705,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"dev": true,
 			"requires": {
 				"domelementtype": "1.1.3",
 				"entities": "1.1.1"
@@ -1524,19 +1714,22 @@
 				"domelementtype": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+					"dev": true
 				}
 			}
 		},
 		"domelementtype": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"dev": true
 		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
 			"requires": {
 				"webidl-conversions": "4.0.2"
 			}
@@ -1545,6 +1738,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
 			"integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+			"dev": true,
 			"requires": {
 				"domelementtype": "1.3.0"
 			}
@@ -1553,6 +1747,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"dev": true,
 			"requires": {
 				"dom-serializer": "0.1.0",
 				"domelementtype": "1.3.0"
@@ -1562,6 +1757,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.2.0.tgz",
 			"integrity": "sha1-4WXklLAPgaO262Q4XL9tG0hrepk=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "0.2.0",
 				"glob": "4.5.3",
@@ -1572,6 +1768,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
 					"integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "0.1.0",
 						"minimist": "0.1.0"
@@ -1581,6 +1778,7 @@
 					"version": "4.5.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1592,6 +1790,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -1599,7 +1798,8 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
@@ -1607,6 +1807,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
@@ -1615,7 +1816,8 @@
 		"electron-to-chromium": {
 			"version": "1.3.36",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
-			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
+			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -1628,12 +1830,14 @@
 		"entities": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+			"dev": true
 		},
 		"enzyme": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
 			"integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
+			"dev": true,
 			"requires": {
 				"cheerio": "1.0.0-rc.2",
 				"function.prototype.name": "1.1.0",
@@ -1657,6 +1861,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz",
 			"integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
+			"dev": true,
 			"requires": {
 				"enzyme-adapter-utils": "1.3.0",
 				"lodash": "4.17.5",
@@ -1671,6 +1876,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
 			"integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
 				"object.assign": "4.1.0",
@@ -1681,6 +1887,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1693,6 +1900,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1702,12 +1910,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"dev": true,
 			"requires": {
 				"esprima": "3.1.3",
 				"estraverse": "4.2.0",
@@ -1725,6 +1935,7 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -1733,6 +1944,7 @@
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
@@ -1782,6 +1994,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -1790,6 +2003,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -1821,6 +2035,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -1831,6 +2046,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"dev": true,
 			"requires": {
 				"doctrine": "2.1.0",
 				"has": "1.0.1",
@@ -1842,6 +2058,7 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
 			"requires": {
 				"esrecurse": "4.2.1",
 				"estraverse": "4.2.0"
@@ -1850,12 +2067,14 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.5.1",
 				"acorn-jsx": "3.0.1"
@@ -1864,12 +2083,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1878,6 +2099,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1885,22 +2107,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
@@ -1910,6 +2136,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "2.2.3"
@@ -1918,12 +2145,14 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
 		},
 		"external-editor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -1934,6 +2163,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
@@ -1942,22 +2172,26 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fbjs": {
 			"version": "0.8.16",
@@ -1984,6 +2218,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
@@ -1992,6 +2227,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.3.0",
 				"object-assign": "4.1.1"
@@ -2001,12 +2237,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -2020,6 +2258,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -2031,12 +2270,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
 			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
@@ -2045,17 +2286,20 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
@@ -2065,17 +2309,20 @@
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.9.2",
@@ -2085,11 +2332,13 @@
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -2098,16 +2347,19 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -2117,35 +2369,42 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -2154,6 +2413,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -2161,6 +2421,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2168,6 +2429,7 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -2175,44 +2437,53 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -2220,6 +2491,7 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -2228,6 +2500,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2235,6 +2508,7 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2243,25 +2517,30 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2270,20 +2549,24 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -2293,11 +2576,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -2308,6 +2593,7 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -2318,6 +2604,7 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -2333,6 +2620,7 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -2341,6 +2629,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2348,6 +2637,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -2359,16 +2649,19 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -2378,11 +2671,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2392,11 +2687,13 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -2407,6 +2704,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -2414,16 +2712,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2431,20 +2732,24 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2453,16 +2758,19 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2471,16 +2779,19 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2492,17 +2803,20 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -2510,17 +2824,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2528,11 +2845,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -2551,6 +2870,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2560,6 +2880,7 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2570,21 +2891,25 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2592,16 +2917,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2610,30 +2938,36 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2645,6 +2979,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2652,6 +2987,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2665,6 +3001,7 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2694,32 +3031,38 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2727,6 +3070,7 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2743,6 +3087,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2750,6 +3095,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2757,6 +3103,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2766,11 +3113,13 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2778,11 +3127,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2792,6 +3143,7 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2807,6 +3159,7 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2815,6 +3168,7 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2823,25 +3177,30 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2850,6 +3209,7 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2857,19 +3217,22 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"function.prototype.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"function-bind": "1.1.1",
@@ -2879,22 +3242,26 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -2903,6 +3270,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2916,6 +3284,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
@@ -2926,6 +3295,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2933,12 +3303,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2951,22 +3323,26 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"har-schema": "2.0.0"
@@ -2976,6 +3352,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -2984,6 +3361,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2991,17 +3369,20 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
 		},
 		"hawk": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"dev": true,
 			"requires": {
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
@@ -3012,12 +3393,14 @@
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"hoek": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+			"dev": true
 		},
 		"hoist-non-react-statics": {
 			"version": "2.5.0",
@@ -3028,6 +3411,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -3037,6 +3421,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
 			"requires": {
 				"whatwg-encoding": "1.0.3"
 			}
@@ -3045,6 +3430,7 @@
 			"version": "3.9.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
 			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+			"dev": true,
 			"requires": {
 				"domelementtype": "1.3.0",
 				"domhandler": "2.4.1",
@@ -3058,6 +3444,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"jsprim": "1.4.1",
@@ -3072,17 +3459,20 @@
 		"ignore": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -3091,12 +3481,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
 				"chalk": "2.3.2",
@@ -3117,12 +3509,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -3131,6 +3525,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3141,6 +3536,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -3149,6 +3545,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -3159,6 +3556,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
 			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -3167,6 +3565,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
@@ -3175,33 +3574,39 @@
 		"is-boolean-object": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M="
+			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
@@ -3211,17 +3616,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
 			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3229,12 +3637,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -3243,6 +3653,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -3251,17 +3662,20 @@
 		"is-number-object": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k="
+			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+			"dev": true
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -3270,6 +3684,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -3278,23 +3693,27 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true,
 			"optional": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -3302,7 +3721,8 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -3312,42 +3732,50 @@
 		"is-string": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
+			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+			"dev": true
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -3365,7 +3793,8 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -3376,6 +3805,7 @@
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -3385,12 +3815,14 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "11.6.2",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
 			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"dev": true,
 			"requires": {
 				"abab": "1.0.4",
 				"acorn": "5.5.1",
@@ -3423,49 +3855,58 @@
 				"parse5": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+					"dev": true
 				}
 			}
 		},
 		"jsdom-global": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
+			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+			"dev": true
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -3477,6 +3918,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3"
 			}
@@ -3484,12 +3926,14 @@
 		"just-extend": {
 			"version": "1.1.27",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
@@ -3497,12 +3941,14 @@
 		"left-pad": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -3511,37 +3957,44 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
 		},
 		"lodash-es": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+			"dev": true
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
 		},
 		"lolex": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
@@ -3555,6 +4008,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3564,6 +4018,7 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
@@ -3584,12 +4039,14 @@
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.18",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.33.0"
 			}
@@ -3597,12 +4054,14 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -3610,12 +4069,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3624,6 +4085,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
 			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
 				"commander": "2.11.0",
@@ -3640,12 +4102,14 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3653,12 +4117,14 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -3668,33 +4134,39 @@
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+			"dev": true
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
 			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"nearley": {
 			"version": "2.12.1",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.12.1.tgz",
 			"integrity": "sha512-FQyYKOKm5DgqzJkR6C9GhlRoYdrcRKXJF2qi9Y/4K4Cd2BN4Sglven0LO3dR8w1BQ72Ty5s+/XzA/FtN9Gx50w==",
+			"dev": true,
 			"requires": {
 				"moo": "0.4.3",
 				"nomnom": "1.6.2",
@@ -3707,6 +4179,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
 			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3728,6 +4201,7 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
 			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+			"dev": true,
 			"requires": {
 				"colors": "0.5.1",
 				"underscore": "1.4.4"
@@ -3737,6 +4211,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -3745,6 +4220,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+			"dev": true,
 			"requires": {
 				"boolbase": "1.0.0"
 			}
@@ -3752,17 +4228,20 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwmatcher": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+			"dev": true
 		},
 		"nyc": {
 			"version": "11.4.1",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
 			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3796,6 +4275,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2",
 						"longest": "1.0.1",
@@ -3804,53 +4284,64 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -3860,6 +4351,7 @@
 				"babel-generator": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.26.0",
@@ -3874,6 +4366,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0"
 					}
@@ -3881,6 +4374,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "2.5.3",
 						"regenerator-runtime": "0.11.1"
@@ -3889,6 +4383,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"babel-traverse": "6.26.0",
@@ -3900,6 +4395,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.26.0",
 						"babel-messages": "6.23.0",
@@ -3915,6 +4411,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
@@ -3924,15 +4421,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3941,6 +4441,7 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3949,11 +4450,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -3963,11 +4466,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -3977,6 +4482,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3988,6 +4494,7 @@
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -3998,33 +4505,40 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "4.1.1",
 						"which": "1.3.0"
@@ -4033,21 +4547,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -4055,6 +4573,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -4062,21 +4581,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -4090,6 +4613,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "4.1.1",
 								"shebang-command": "1.2.0",
@@ -4101,6 +4625,7 @@
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -4108,6 +4633,7 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -4115,17 +4641,20 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -4137,6 +4666,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -4146,17 +4676,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -4164,6 +4697,7 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -4171,19 +4705,23 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -4196,6 +4734,7 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -4204,21 +4743,25 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -4229,6 +4772,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -4238,25 +4782,30 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -4264,56 +4813,67 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -4321,6 +4881,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -4328,6 +4889,7 @@
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -4335,48 +4897,58 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -4384,6 +4956,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.9.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "6.26.0",
 						"babel-template": "6.26.0",
@@ -4397,6 +4970,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.1",
 						"mkdirp": "0.5.1",
@@ -4407,6 +4981,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -4416,6 +4991,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.1.1",
@@ -4427,6 +5003,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -4436,21 +5013,25 @@
 				"istanbul-reports": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -4458,11 +5039,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -4470,6 +5053,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -4481,6 +5065,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "2.0.0",
 						"path-exists": "3.0.0"
@@ -4488,21 +5073,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.2"
 					}
@@ -4510,6 +5099,7 @@
 				"lru-cache": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -4518,17 +5108,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "1.1.0"
 					}
@@ -4536,6 +5129,7 @@
 				"merge-source-map": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
 					}
@@ -4543,6 +5137,7 @@
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -4561,33 +5156,39 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.5.0",
 						"is-builtin-module": "1.0.0",
@@ -4598,6 +5199,7 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.1.0"
 					}
@@ -4605,21 +5207,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -4628,6 +5234,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -4635,6 +5242,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -4642,11 +5250,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "0.7.0",
 						"lcid": "1.0.0",
@@ -4655,15 +5265,18 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "1.1.0"
 					}
@@ -4671,6 +5284,7 @@
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.3",
@@ -4681,6 +5295,7 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
@@ -4688,25 +5303,30 @@
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -4715,15 +5335,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -4731,6 +5354,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					},
@@ -4738,6 +5362,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4747,15 +5372,18 @@
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -4764,6 +5392,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -4771,6 +5400,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -4780,6 +5410,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -4789,6 +5420,7 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -4798,6 +5430,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -4806,6 +5439,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4815,49 +5449,59 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3"
 					}
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -4866,44 +5510,53 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"semver": {
 					"version": "5.4.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -4916,21 +5569,25 @@
 				"spdx-correct": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-license-ids": "1.2.2"
 					}
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4938,15 +5595,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -4956,6 +5616,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4963,21 +5624,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "2.3.11",
@@ -4988,15 +5653,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.7",
@@ -5007,6 +5675,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -5020,11 +5689,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "1.0.2",
 						"spdx-expression-parse": "1.0.4"
@@ -5033,26 +5704,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -5061,6 +5737,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -5071,11 +5748,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -5084,15 +5763,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
@@ -5111,6 +5793,7 @@
 						"cliui": {
 							"version": "3.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
@@ -5120,6 +5803,7 @@
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"code-point-at": "1.1.0",
 										"is-fullwidth-code-point": "1.0.0",
@@ -5133,13 +5817,15 @@
 				"yargs-parser": {
 					"version": "8.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -5148,7 +5834,8 @@
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -5158,22 +5845,26 @@
 		"object-inspect": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
-			"integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
+			"integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
+			"dev": true
 		},
 		"object-is": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"function-bind": "1.1.1",
@@ -5185,6 +5876,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0",
@@ -5196,6 +5888,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
@@ -5206,6 +5899,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0",
@@ -5217,6 +5911,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -5225,6 +5920,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -5233,6 +5929,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -5245,17 +5942,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -5266,6 +5966,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
@@ -5278,6 +5979,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+			"dev": true,
 			"requires": {
 				"@types/node": "9.4.6"
 			}
@@ -5285,17 +5987,20 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -5303,34 +6008,40 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -5338,38 +6049,45 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
 		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -5392,22 +6110,26 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"dev": true
 		},
 		"raf": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
 			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+			"dev": true,
 			"requires": {
 				"performance-now": "2.1.0"
 			}
@@ -5415,12 +6137,14 @@
 		"railroad-diagrams": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+			"dev": true
 		},
 		"randexp": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
 			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
 				"ret": "0.1.15"
@@ -5430,6 +6154,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -5440,6 +6165,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "3.2.2"
@@ -5449,6 +6175,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-buffer": "1.1.6"
@@ -5460,6 +6187,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "1.1.6"
@@ -5471,6 +6199,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
 			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -5482,6 +6211,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
 			"integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -5493,6 +6223,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.7.0.tgz",
 			"integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -5504,6 +6235,7 @@
 			"version": "5.0.7",
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
 			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+			"dev": true,
 			"requires": {
 				"hoist-non-react-statics": "2.5.0",
 				"invariant": "2.2.3",
@@ -5517,6 +6249,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
 			"integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"object-assign": "4.1.1",
@@ -5527,6 +6260,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -5541,6 +6275,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -5564,6 +6299,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
 				"lodash-es": "4.17.5",
@@ -5575,6 +6311,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
 			"integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+			"dev": true,
 			"requires": {
 				"lodash.isplainobject": "4.0.6"
 			}
@@ -5582,17 +6319,20 @@
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -5603,6 +6343,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -5612,6 +6353,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -5621,12 +6363,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -5634,30 +6378,35 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
 			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -5666,6 +6415,7 @@
 			"version": "2.83.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "0.7.0",
 				"aws4": "1.6.0",
@@ -5695,6 +6445,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5"
 			}
@@ -5703,6 +6454,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "1.1.1",
@@ -5713,6 +6465,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -5721,12 +6474,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
@@ -5735,12 +6490,14 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -5748,12 +6505,14 @@
 		"rollup": {
 			"version": "0.55.5",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
-			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA=="
+			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
 			"integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+			"dev": true,
 			"requires": {
 				"rollup-pluginutils": "1.5.2"
 			}
@@ -5762,6 +6521,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -5771,6 +6531,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+			"dev": true,
 			"requires": {
 				"lodash.flattendeep": "4.4.0",
 				"nearley": "2.12.1"
@@ -5780,6 +6541,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
 			}
@@ -5787,12 +6549,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
 			}
@@ -5800,27 +6564,32 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
@@ -5832,6 +6601,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -5839,17 +6609,20 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
 			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
@@ -5864,6 +6637,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5873,17 +6647,20 @@
 		"sinon-chai": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
 			}
@@ -5892,6 +6669,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"dev": true,
 			"requires": {
 				"hoek": "4.2.1"
 			}
@@ -5899,12 +6677,14 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
 			}
@@ -5912,12 +6692,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -5932,12 +6714,14 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5946,6 +6730,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -5954,12 +6739,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -5969,12 +6756,14 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -5982,12 +6771,14 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
@@ -5997,12 +6788,14 @@
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
@@ -6016,6 +6809,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -6024,6 +6818,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -6034,6 +6829,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -6043,22 +6839,26 @@
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
 			}
@@ -6066,12 +6866,14 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"dev": true,
 			"requires": {
 				"punycode": "1.4.1"
 			}
@@ -6080,6 +6882,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
 			"requires": {
 				"punycode": "2.1.0"
 			},
@@ -6087,19 +6890,22 @@
 				"punycode": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+					"dev": true
 				}
 			}
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -6108,12 +6914,14 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -6121,22 +6929,26 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+			"dev": true
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz",
 			"integrity": "sha1-kcV0146gW4HtgSRNUOww2CQMNW8=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"dts-bundle": "0.2.0",
@@ -6146,7 +6958,8 @@
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
@@ -6158,27 +6971,32 @@
 		"underscore": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -6187,6 +7005,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
@@ -6197,6 +7016,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "0.1.2"
 			}
@@ -6204,12 +7024,14 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
 			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -6223,6 +7045,7 @@
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
 			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"dev": true,
 			"requires": {
 				"lodash.sortby": "4.7.0",
 				"tr46": "1.0.1",
@@ -6233,6 +7056,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -6240,17 +7064,20 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -6259,6 +7086,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"dev": true,
 			"requires": {
 				"async-limiter": "1.0.0",
 				"safe-buffer": "5.1.1"
@@ -6267,12 +7095,14 @@
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		}
 	}
 }

--- a/packages/react-redux-subspace/package.json
+++ b/packages/react-redux-subspace/package.json
@@ -46,6 +46,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/packages/redux-subspace-loop/.babelrc.js
+++ b/packages/redux-subspace-loop/.babelrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'stage-3',
   ],
   plugins: [
+    'annotate-pure-calls',
     cjs && 'transform-es2015-modules-commonjs',
   ].filter(Boolean),
 }

--- a/packages/redux-subspace-loop/package-lock.json
+++ b/packages/redux-subspace-loop/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "redux-subspace-loop",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
 			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.40"
 			}
@@ -14,6 +17,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
 			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40",
 				"jsesc": "2.5.1",
@@ -25,7 +29,8 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"dev": true
 				}
 			}
 		},
@@ -33,6 +38,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
 			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.40",
 				"@babel/template": "7.0.0-beta.40",
@@ -43,6 +49,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
 			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40"
 			}
@@ -51,6 +58,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -61,6 +69,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -69,6 +78,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -79,6 +89,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -89,6 +100,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
 			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/types": "7.0.0-beta.40",
@@ -99,7 +111,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -107,6 +120,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
 			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/generator": "7.0.0-beta.40",
@@ -122,7 +136,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -143,6 +158,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
 			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -160,6 +176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
 			"requires": {
 				"samsam": "1.3.0"
 			}
@@ -167,12 +184,14 @@
 		"acorn": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -180,7 +199,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -188,6 +208,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.1.0",
@@ -198,27 +219,32 @@
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"micromatch": "2.3.11",
@@ -229,6 +255,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -237,6 +264,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
@@ -246,12 +274,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
 			"optional": true
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0"
@@ -261,6 +291,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -268,39 +299,46 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true,
 			"optional": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"babel-cli": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-polyfill": "6.26.0",
@@ -323,6 +361,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -333,6 +372,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -359,6 +399,7 @@
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/traverse": "7.0.0-beta.40",
@@ -371,7 +412,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -379,6 +421,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -394,6 +437,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -404,6 +448,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -414,6 +459,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -425,6 +471,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -436,6 +483,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -446,6 +494,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -458,6 +507,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -467,6 +517,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -476,6 +527,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -485,6 +537,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -495,6 +548,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -507,6 +561,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -520,6 +575,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -529,14 +585,25 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-annotate-pure-calls": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz",
+			"integrity": "sha512-0IP5H7eRCKPKcas8JCJf11c6OrSNmYmc3Ehaz+JFLasa4a2pLvfnfOeMBYMdqmutXjXcoqWA+H7ZyzHo008S/w==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -545,6 +612,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -552,42 +620,56 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -598,6 +680,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -608,6 +691,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -616,6 +700,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -624,6 +709,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0",
@@ -636,6 +722,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
@@ -652,6 +739,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -661,6 +749,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -669,6 +758,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -678,6 +768,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -686,6 +777,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -696,6 +788,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -704,6 +797,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -714,6 +808,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -725,6 +820,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -735,6 +831,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -745,6 +842,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.26.0"
@@ -754,6 +852,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -767,6 +866,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -776,6 +876,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -784,6 +885,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -794,6 +896,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -802,6 +905,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -810,6 +914,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -820,6 +925,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -830,6 +936,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -839,6 +946,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -848,6 +956,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -856,6 +965,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -866,6 +976,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -875,6 +986,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -884,6 +996,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.10.1"
 			}
@@ -892,6 +1005,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -901,6 +1015,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"core-js": "2.5.3",
@@ -910,7 +1025,8 @@
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -918,6 +1034,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -955,6 +1072,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -963,6 +1081,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -976,6 +1095,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -988,6 +1108,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -1002,6 +1123,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.5.3",
 				"regenerator-runtime": "0.11.1"
@@ -1011,6 +1133,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1023,6 +1146,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1039,6 +1163,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1049,23 +1174,27 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1075,6 +1204,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
@@ -1085,12 +1215,14 @@
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
 		},
 		"browserslist": {
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000813",
 				"electron-to-chromium": "1.3.36"
@@ -1100,6 +1232,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1107,17 +1240,20 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000813",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz",
-			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
+			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A==",
+			"dev": true
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"check-error": "1.0.2",
@@ -1131,6 +1267,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1142,17 +1279,20 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
@@ -1169,12 +1309,14 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
 			}
@@ -1182,17 +1324,20 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1200,22 +1345,26 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5",
@@ -1225,22 +1374,26 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-env": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.3.tgz",
 			"integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"is-windows": "1.0.2"
@@ -1250,6 +1403,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -1260,6 +1414,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1268,6 +1423,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1275,12 +1431,14 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1290,6 +1448,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1304,6 +1463,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1311,12 +1471,14 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
 			}
@@ -1325,6 +1487,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.2.0.tgz",
 			"integrity": "sha1-4WXklLAPgaO262Q4XL9tG0hrepk=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "0.2.0",
 				"glob": "4.5.3",
@@ -1335,6 +1498,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
 					"integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "0.1.0",
 						"minimist": "0.1.0"
@@ -1344,6 +1508,7 @@
 					"version": "4.5.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1355,6 +1520,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -1362,19 +1528,22 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
 		"electron-to-chromium": {
 			"version": "1.3.36",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
-			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
+			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -1383,6 +1552,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1395,6 +1565,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1404,12 +1575,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"eslint": {
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
@@ -1459,6 +1632,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -1467,6 +1641,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -1498,6 +1673,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -1508,6 +1684,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"dev": true,
 			"requires": {
 				"doctrine": "2.1.0",
 				"has": "1.0.1",
@@ -1519,6 +1696,7 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
 			"requires": {
 				"esrecurse": "4.2.1",
 				"estraverse": "4.2.0"
@@ -1527,12 +1705,14 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.5.1",
 				"acorn-jsx": "3.0.1"
@@ -1541,12 +1721,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1555,6 +1737,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1562,22 +1745,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
@@ -1587,6 +1774,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "2.2.3"
@@ -1596,6 +1784,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -1606,6 +1795,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
@@ -1614,22 +1804,26 @@
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fbjs": {
 			"version": "0.8.16",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"dev": true,
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -1643,7 +1837,8 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
 				}
 			}
 		},
@@ -1651,6 +1846,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
@@ -1659,6 +1855,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.3.0",
 				"object-assign": "4.1.1"
@@ -1668,12 +1865,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -1687,6 +1886,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1698,12 +1898,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
 			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
@@ -1712,22 +1914,26 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.9.2",
@@ -1737,11 +1943,13 @@
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1750,16 +1958,19 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1769,35 +1980,42 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1806,6 +2024,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1813,6 +2032,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1820,6 +2040,7 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1827,44 +2048,53 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -1872,6 +2102,7 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1880,6 +2111,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -1887,6 +2119,7 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1895,25 +2128,30 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1922,20 +2160,24 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -1945,11 +2187,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1960,6 +2204,7 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1970,6 +2215,7 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -1985,6 +2231,7 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1993,6 +2240,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2000,6 +2248,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -2011,16 +2260,19 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -2030,11 +2282,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2044,11 +2298,13 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -2059,6 +2315,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -2066,16 +2323,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2083,20 +2343,24 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2105,16 +2369,19 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2123,16 +2390,19 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2144,17 +2414,20 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -2162,17 +2435,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2180,11 +2456,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -2203,6 +2481,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2212,6 +2491,7 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2222,21 +2502,25 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2244,16 +2528,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2262,30 +2549,36 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2297,6 +2590,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2304,6 +2598,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2317,6 +2612,7 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2346,32 +2642,38 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2379,6 +2681,7 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2395,6 +2698,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2402,6 +2706,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2409,6 +2714,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2418,11 +2724,13 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2430,11 +2738,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2444,6 +2754,7 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2459,6 +2770,7 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2467,6 +2779,7 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2475,25 +2788,30 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2502,6 +2820,7 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2509,34 +2828,40 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2550,6 +2875,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
@@ -2560,6 +2886,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2567,12 +2894,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2585,17 +2914,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -2604,6 +2936,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2611,17 +2944,20 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2630,22 +2966,26 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2654,12 +2994,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
 				"chalk": "2.3.2",
@@ -2680,12 +3022,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -2694,6 +3038,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -2704,6 +3049,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -2712,6 +3058,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -2722,6 +3069,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
 			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -2730,6 +3078,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
@@ -2738,28 +3087,33 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
@@ -2769,17 +3123,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
 			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2787,12 +3144,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2801,6 +3160,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -2809,12 +3169,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -2823,6 +3185,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -2831,23 +3194,27 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true,
 			"optional": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -2855,37 +3222,44 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -2895,6 +3269,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "1.7.3",
 				"whatwg-fetch": "2.0.3"
@@ -2903,12 +3278,14 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -2917,27 +3294,32 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsx-ast-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3"
 			}
@@ -2945,12 +3327,14 @@
 		"just-extend": {
 			"version": "1.1.27",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
@@ -2959,6 +3343,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -2967,32 +3352,38 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
 		},
 		"lodash-es": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
 		},
 		"lolex": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -3001,6 +3392,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3010,6 +3402,7 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
@@ -3030,12 +3423,14 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -3043,12 +3438,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3057,6 +3454,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
 			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
 				"commander": "2.11.0",
@@ -3073,12 +3471,14 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3086,12 +3486,14 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -3101,28 +3503,33 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
 			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"nise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
 			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3135,6 +3542,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -3144,6 +3552,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -3151,12 +3560,14 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nyc": {
 			"version": "11.4.1",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
 			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3190,6 +3601,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2",
 						"longest": "1.0.1",
@@ -3198,53 +3610,64 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -3254,6 +3677,7 @@
 				"babel-generator": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.26.0",
@@ -3268,6 +3692,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0"
 					}
@@ -3275,6 +3700,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "2.5.3",
 						"regenerator-runtime": "0.11.1"
@@ -3283,6 +3709,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"babel-traverse": "6.26.0",
@@ -3294,6 +3721,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.26.0",
 						"babel-messages": "6.23.0",
@@ -3309,6 +3737,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
@@ -3318,15 +3747,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3335,6 +3767,7 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3343,11 +3776,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -3357,11 +3792,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -3371,6 +3808,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3382,6 +3820,7 @@
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -3392,33 +3831,40 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "4.1.1",
 						"which": "1.3.0"
@@ -3427,21 +3873,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -3449,6 +3899,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -3456,21 +3907,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -3484,6 +3939,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "4.1.1",
 								"shebang-command": "1.2.0",
@@ -3495,6 +3951,7 @@
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3502,6 +3959,7 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -3509,17 +3967,20 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -3531,6 +3992,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -3540,17 +4002,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -3558,6 +4023,7 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -3565,19 +4031,23 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -3590,6 +4060,7 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -3598,21 +4069,25 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -3623,6 +4098,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -3632,25 +4108,30 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -3658,56 +4139,67 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3715,6 +4207,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3722,6 +4215,7 @@
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3729,48 +4223,58 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -3778,6 +4282,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.9.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "6.26.0",
 						"babel-template": "6.26.0",
@@ -3791,6 +4296,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.1",
 						"mkdirp": "0.5.1",
@@ -3801,6 +4307,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -3810,6 +4317,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.1.1",
@@ -3821,6 +4329,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -3830,21 +4339,25 @@
 				"istanbul-reports": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3852,11 +4365,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -3864,6 +4379,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -3875,6 +4391,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "2.0.0",
 						"path-exists": "3.0.0"
@@ -3882,21 +4399,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.2"
 					}
@@ -3904,6 +4425,7 @@
 				"lru-cache": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -3912,17 +4434,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "1.1.0"
 					}
@@ -3930,6 +4455,7 @@
 				"merge-source-map": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
 					}
@@ -3937,6 +4463,7 @@
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3955,33 +4482,39 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.5.0",
 						"is-builtin-module": "1.0.0",
@@ -3992,6 +4525,7 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.1.0"
 					}
@@ -3999,21 +4533,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -4022,6 +4560,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -4029,6 +4568,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -4036,11 +4576,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "0.7.0",
 						"lcid": "1.0.0",
@@ -4049,15 +4591,18 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "1.1.0"
 					}
@@ -4065,6 +4610,7 @@
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.3",
@@ -4075,6 +4621,7 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
@@ -4082,25 +4629,30 @@
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -4109,15 +4661,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -4125,6 +4680,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					},
@@ -4132,6 +4688,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4141,15 +4698,18 @@
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -4158,6 +4718,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -4165,6 +4726,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -4174,6 +4736,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -4183,6 +4746,7 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -4192,6 +4756,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -4200,6 +4765,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4209,49 +4775,59 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3"
 					}
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -4260,44 +4836,53 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"semver": {
 					"version": "5.4.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -4310,21 +4895,25 @@
 				"spdx-correct": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-license-ids": "1.2.2"
 					}
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4332,15 +4921,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -4350,6 +4942,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4357,21 +4950,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "2.3.11",
@@ -4382,15 +4979,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.7",
@@ -4401,6 +5001,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -4414,11 +5015,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "1.0.2",
 						"spdx-expression-parse": "1.0.4"
@@ -4427,26 +5030,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -4455,6 +5063,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -4465,11 +5074,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -4478,15 +5089,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
@@ -4505,6 +5119,7 @@
 						"cliui": {
 							"version": "3.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
@@ -4514,6 +5129,7 @@
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"code-point-at": "1.1.0",
 										"is-fullwidth-code-point": "1.0.0",
@@ -4527,13 +5143,15 @@
 				"yargs-parser": {
 					"version": "8.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -4542,17 +5160,20 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
@@ -4563,6 +5184,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4571,6 +5193,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -4579,6 +5202,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4591,17 +5215,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4612,6 +5239,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
@@ -4623,17 +5251,20 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -4641,29 +5272,34 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4671,38 +5307,45 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -4711,6 +5354,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -4720,12 +5364,14 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -4736,6 +5382,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "3.2.2"
@@ -4745,6 +5392,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-buffer": "1.1.6"
@@ -4756,6 +5404,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "1.1.6"
@@ -4767,6 +5416,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4781,6 +5431,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4793,6 +5444,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
 				"lodash-es": "4.17.5",
@@ -4803,12 +5455,14 @@
 		"redux-loop": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/redux-loop/-/redux-loop-3.2.2.tgz",
-			"integrity": "sha512-DWNBSPS1rnGe99cJ4wKrgeOVFjaar50biAiDpwwnL3ZGp/DMNJwVrQoipD7o4y3hALVu0AOZQU2n6mNR7SaU3Q=="
+			"integrity": "sha512-DWNBSPS1rnGe99cJ4wKrgeOVFjaar50biAiDpwwnL3ZGp/DMNJwVrQoipD7o4y3hALVu0AOZQU2n6mNR7SaU3Q==",
+			"dev": true
 		},
 		"redux-mock-store": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
 			"integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+			"dev": true,
 			"requires": {
 				"lodash.isplainobject": "4.0.6"
 			}
@@ -4816,17 +5470,20 @@
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -4837,6 +5494,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -4846,6 +5504,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -4855,12 +5514,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4868,30 +5529,35 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
 			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4900,6 +5566,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4908,12 +5575,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
@@ -4923,6 +5592,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -4930,12 +5600,14 @@
 		"rollup": {
 			"version": "0.55.5",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
-			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA=="
+			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
 			"integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+			"dev": true,
 			"requires": {
 				"rollup-pluginutils": "1.5.2"
 			}
@@ -4944,6 +5616,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -4953,6 +5626,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
 			}
@@ -4960,12 +5634,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
 			}
@@ -4973,33 +5649,39 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -5007,17 +5689,20 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
 			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
@@ -5032,6 +5717,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5041,17 +5727,20 @@
 		"sinon-chai": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
 			}
@@ -5059,12 +5748,14 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
 			}
@@ -5072,12 +5763,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5086,6 +5779,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -5094,12 +5788,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -5110,6 +5806,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -5117,22 +5814,26 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
@@ -5146,6 +5847,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5154,6 +5856,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -5164,6 +5867,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5173,22 +5877,26 @@
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
 			}
@@ -5196,17 +5904,20 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -5214,22 +5925,26 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+			"dev": true
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz",
 			"integrity": "sha1-kcV0146gW4HtgSRNUOww2CQMNW8=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"dts-bundle": "0.2.0",
@@ -5239,29 +5954,34 @@
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
 		"ua-parser-js": {
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5269,12 +5989,14 @@
 		"whatwg-fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5282,17 +6004,20 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5300,7 +6025,8 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		}
 	}
 }

--- a/packages/redux-subspace-loop/package.json
+++ b/packages/redux-subspace-loop/package.json
@@ -42,6 +42,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/packages/redux-subspace-observable/.babelrc.js
+++ b/packages/redux-subspace-observable/.babelrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'stage-3',
   ],
   plugins: [
+    'annotate-pure-calls',
     cjs && 'transform-es2015-modules-commonjs',
     'transform-function-bind'
   ].filter(Boolean),

--- a/packages/redux-subspace-observable/package-lock.json
+++ b/packages/redux-subspace-observable/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "redux-subspace-observable",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
 			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.40"
 			}
@@ -14,6 +17,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
 			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40",
 				"jsesc": "2.5.1",
@@ -25,7 +29,8 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"dev": true
 				}
 			}
 		},
@@ -33,6 +38,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
 			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.40",
 				"@babel/template": "7.0.0-beta.40",
@@ -43,6 +49,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
 			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40"
 			}
@@ -51,6 +58,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -61,6 +69,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -69,6 +78,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -79,6 +89,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -89,6 +100,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
 			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/types": "7.0.0-beta.40",
@@ -99,7 +111,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -107,6 +120,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
 			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/generator": "7.0.0-beta.40",
@@ -122,7 +136,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -143,6 +158,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
 			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -160,6 +176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
 			"requires": {
 				"samsam": "1.3.0"
 			}
@@ -177,12 +194,14 @@
 		"acorn": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -190,7 +209,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -198,6 +218,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.1.0",
@@ -208,27 +229,32 @@
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"micromatch": "2.3.11",
@@ -239,6 +265,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -247,6 +274,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
@@ -256,12 +284,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
 			"optional": true
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0"
@@ -271,6 +301,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -278,39 +309,46 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true,
 			"optional": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"babel-cli": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-polyfill": "6.26.0",
@@ -333,6 +371,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -343,6 +382,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -369,6 +409,7 @@
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/traverse": "7.0.0-beta.40",
@@ -381,7 +422,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -389,6 +431,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -404,6 +447,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -414,6 +458,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -424,6 +469,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -435,6 +481,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -446,6 +493,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -456,6 +504,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -468,6 +517,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -477,6 +527,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -486,6 +537,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -495,6 +547,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -505,6 +558,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -517,6 +571,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -530,6 +585,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -539,14 +595,25 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-annotate-pure-calls": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz",
+			"integrity": "sha512-0IP5H7eRCKPKcas8JCJf11c6OrSNmYmc3Ehaz+JFLasa4a2pLvfnfOeMBYMdqmutXjXcoqWA+H7ZyzHo008S/w==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -555,6 +622,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -562,47 +630,62 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-function-bind": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
-			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
+			"integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -613,6 +696,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -623,6 +707,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -631,6 +716,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -639,6 +725,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0",
@@ -651,6 +738,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
@@ -667,6 +755,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -676,6 +765,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -684,6 +774,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -693,6 +784,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -701,6 +793,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -711,6 +804,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -719,6 +813,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -729,6 +824,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -740,6 +836,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -750,6 +847,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -760,6 +858,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.26.0"
@@ -769,6 +868,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -782,6 +882,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -791,6 +892,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -799,6 +901,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -809,6 +912,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -817,6 +921,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -825,6 +930,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -835,6 +941,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -845,6 +952,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -854,6 +962,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
 			"integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-function-bind": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -863,6 +972,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -872,6 +982,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -880,6 +991,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -890,6 +1002,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -899,6 +1012,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -908,6 +1022,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.10.1"
 			}
@@ -916,6 +1031,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -925,6 +1041,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"core-js": "2.5.3",
@@ -934,7 +1051,8 @@
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -942,6 +1060,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -979,6 +1098,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -987,6 +1107,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -1000,6 +1121,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -1012,6 +1134,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -1026,6 +1149,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.5.3",
 				"regenerator-runtime": "0.11.1"
@@ -1035,6 +1159,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1047,6 +1172,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1063,6 +1189,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1073,23 +1200,27 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1099,6 +1230,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
@@ -1109,12 +1241,14 @@
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
 		},
 		"browserslist": {
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000813",
 				"electron-to-chromium": "1.3.36"
@@ -1124,6 +1258,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1131,17 +1266,20 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000813",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz",
-			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
+			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A==",
+			"dev": true
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"check-error": "1.0.2",
@@ -1155,6 +1293,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1166,17 +1305,20 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
@@ -1193,12 +1335,14 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
 			}
@@ -1206,17 +1350,20 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1224,22 +1371,26 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5",
@@ -1249,22 +1400,26 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-env": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.3.tgz",
 			"integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"is-windows": "1.0.2"
@@ -1274,6 +1429,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -1284,6 +1440,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1292,6 +1449,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1299,12 +1457,14 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1314,6 +1474,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1328,6 +1489,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1335,12 +1497,14 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
 			}
@@ -1349,6 +1513,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.2.0.tgz",
 			"integrity": "sha1-4WXklLAPgaO262Q4XL9tG0hrepk=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "0.2.0",
 				"glob": "4.5.3",
@@ -1359,6 +1524,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
 					"integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "0.1.0",
 						"minimist": "0.1.0"
@@ -1368,6 +1534,7 @@
 					"version": "4.5.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1379,6 +1546,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -1386,19 +1554,22 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
 		"electron-to-chromium": {
 			"version": "1.3.36",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
-			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
+			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -1407,6 +1578,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1419,6 +1591,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1428,12 +1601,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"eslint": {
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
@@ -1483,6 +1658,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -1491,6 +1667,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -1522,6 +1699,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -1532,6 +1710,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"dev": true,
 			"requires": {
 				"doctrine": "2.1.0",
 				"has": "1.0.1",
@@ -1543,6 +1722,7 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
 			"requires": {
 				"esrecurse": "4.2.1",
 				"estraverse": "4.2.0"
@@ -1551,12 +1731,14 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.5.1",
 				"acorn-jsx": "3.0.1"
@@ -1565,12 +1747,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1579,6 +1763,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1586,22 +1771,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
@@ -1611,6 +1800,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "2.2.3"
@@ -1620,6 +1810,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -1630,6 +1821,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
@@ -1638,22 +1830,26 @@
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fbjs": {
 			"version": "0.8.16",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"dev": true,
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -1667,7 +1863,8 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
 				}
 			}
 		},
@@ -1675,6 +1872,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
@@ -1683,6 +1881,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.3.0",
 				"object-assign": "4.1.1"
@@ -1692,12 +1891,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -1711,6 +1912,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1722,12 +1924,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
 			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
@@ -1736,22 +1940,26 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.9.2",
@@ -1761,11 +1969,13 @@
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1774,16 +1984,19 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1793,35 +2006,42 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1830,6 +2050,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1837,6 +2058,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1844,6 +2066,7 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1851,44 +2074,53 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -1896,6 +2128,7 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1904,6 +2137,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -1911,6 +2145,7 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1919,25 +2154,30 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1946,20 +2186,24 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -1969,11 +2213,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1984,6 +2230,7 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1994,6 +2241,7 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -2009,6 +2257,7 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -2017,6 +2266,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2024,6 +2274,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -2035,16 +2286,19 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -2054,11 +2308,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2068,11 +2324,13 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -2083,6 +2341,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -2090,16 +2349,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2107,20 +2369,24 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2129,16 +2395,19 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2147,16 +2416,19 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2168,17 +2440,20 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -2186,17 +2461,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2204,11 +2482,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -2227,6 +2507,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2236,6 +2517,7 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2246,21 +2528,25 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2268,16 +2554,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2286,30 +2575,36 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2321,6 +2616,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2328,6 +2624,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2341,6 +2638,7 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2370,32 +2668,38 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2403,6 +2707,7 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2419,6 +2724,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2426,6 +2732,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2433,6 +2740,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2442,11 +2750,13 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2454,11 +2764,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2468,6 +2780,7 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2483,6 +2796,7 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2491,6 +2805,7 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2499,25 +2814,30 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2526,6 +2846,7 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2533,34 +2854,40 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2574,6 +2901,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
@@ -2584,6 +2912,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2591,12 +2920,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2609,17 +2940,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -2628,6 +2962,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2635,17 +2970,20 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2654,22 +2992,26 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2678,12 +3020,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
 				"chalk": "2.3.2",
@@ -2704,12 +3048,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -2718,6 +3064,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -2728,6 +3075,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -2736,6 +3084,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -2746,6 +3095,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
 			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -2754,6 +3104,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
@@ -2762,28 +3113,33 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
@@ -2793,17 +3149,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
 			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2811,12 +3170,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2825,6 +3186,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -2833,12 +3195,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -2847,6 +3211,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -2855,23 +3220,27 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true,
 			"optional": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -2879,37 +3248,44 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -2919,6 +3295,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "1.7.3",
 				"whatwg-fetch": "2.0.3"
@@ -2927,12 +3304,14 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -2941,27 +3320,32 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsx-ast-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3"
 			}
@@ -2969,12 +3353,14 @@
 		"just-extend": {
 			"version": "1.1.27",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
@@ -2983,6 +3369,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -2991,32 +3378,38 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
 		},
 		"lodash-es": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
 		},
 		"lolex": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -3025,6 +3418,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3034,6 +3428,7 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
@@ -3054,12 +3449,14 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -3067,12 +3464,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3081,6 +3480,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
 			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
 				"commander": "2.11.0",
@@ -3097,12 +3497,14 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3110,12 +3512,14 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -3125,28 +3529,33 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
 			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"nise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
 			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3159,6 +3568,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -3168,6 +3578,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -3175,12 +3586,14 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nyc": {
 			"version": "11.4.1",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
 			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3214,6 +3627,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2",
 						"longest": "1.0.1",
@@ -3222,53 +3636,64 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -3278,6 +3703,7 @@
 				"babel-generator": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.26.0",
@@ -3292,6 +3718,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0"
 					}
@@ -3299,6 +3726,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "2.5.3",
 						"regenerator-runtime": "0.11.1"
@@ -3307,6 +3735,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"babel-traverse": "6.26.0",
@@ -3318,6 +3747,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.26.0",
 						"babel-messages": "6.23.0",
@@ -3333,6 +3763,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
@@ -3342,15 +3773,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3359,6 +3793,7 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3367,11 +3802,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -3381,11 +3818,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -3395,6 +3834,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3406,6 +3846,7 @@
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -3416,33 +3857,40 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "4.1.1",
 						"which": "1.3.0"
@@ -3451,21 +3899,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -3473,6 +3925,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -3480,21 +3933,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -3508,6 +3965,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "4.1.1",
 								"shebang-command": "1.2.0",
@@ -3519,6 +3977,7 @@
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3526,6 +3985,7 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -3533,17 +3993,20 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -3555,6 +4018,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -3564,17 +4028,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -3582,6 +4049,7 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -3589,19 +4057,23 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -3614,6 +4086,7 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -3622,21 +4095,25 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -3647,6 +4124,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -3656,25 +4134,30 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -3682,56 +4165,67 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3739,6 +4233,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3746,6 +4241,7 @@
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3753,48 +4249,58 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -3802,6 +4308,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.9.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "6.26.0",
 						"babel-template": "6.26.0",
@@ -3815,6 +4322,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.1",
 						"mkdirp": "0.5.1",
@@ -3825,6 +4333,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -3834,6 +4343,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.1.1",
@@ -3845,6 +4355,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -3854,21 +4365,25 @@
 				"istanbul-reports": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3876,11 +4391,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -3888,6 +4405,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -3899,6 +4417,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "2.0.0",
 						"path-exists": "3.0.0"
@@ -3906,21 +4425,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.2"
 					}
@@ -3928,6 +4451,7 @@
 				"lru-cache": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -3936,17 +4460,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "1.1.0"
 					}
@@ -3954,6 +4481,7 @@
 				"merge-source-map": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
 					}
@@ -3961,6 +4489,7 @@
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3979,33 +4508,39 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.5.0",
 						"is-builtin-module": "1.0.0",
@@ -4016,6 +4551,7 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.1.0"
 					}
@@ -4023,21 +4559,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -4046,6 +4586,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -4053,6 +4594,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -4060,11 +4602,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "0.7.0",
 						"lcid": "1.0.0",
@@ -4073,15 +4617,18 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "1.1.0"
 					}
@@ -4089,6 +4636,7 @@
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.3",
@@ -4099,6 +4647,7 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
@@ -4106,25 +4655,30 @@
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -4133,15 +4687,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -4149,6 +4706,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					},
@@ -4156,6 +4714,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4165,15 +4724,18 @@
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -4182,6 +4744,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -4189,6 +4752,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -4198,6 +4762,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -4207,6 +4772,7 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -4216,6 +4782,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -4224,6 +4791,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4233,49 +4801,59 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3"
 					}
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -4284,44 +4862,53 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"semver": {
 					"version": "5.4.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -4334,21 +4921,25 @@
 				"spdx-correct": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-license-ids": "1.2.2"
 					}
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4356,15 +4947,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -4374,6 +4968,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4381,21 +4976,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "2.3.11",
@@ -4406,15 +5005,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.7",
@@ -4425,6 +5027,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -4438,11 +5041,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "1.0.2",
 						"spdx-expression-parse": "1.0.4"
@@ -4451,26 +5056,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -4479,6 +5089,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -4489,11 +5100,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -4502,15 +5115,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
@@ -4529,6 +5145,7 @@
 						"cliui": {
 							"version": "3.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
@@ -4538,6 +5155,7 @@
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"code-point-at": "1.1.0",
 										"is-fullwidth-code-point": "1.0.0",
@@ -4551,13 +5169,15 @@
 				"yargs-parser": {
 					"version": "8.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -4566,17 +5186,20 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
@@ -4587,6 +5210,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4595,6 +5219,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -4603,6 +5228,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4615,17 +5241,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4636,6 +5265,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
@@ -4647,17 +5277,20 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -4665,29 +5298,34 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4695,38 +5333,45 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -4735,6 +5380,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -4744,12 +5390,14 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -4760,6 +5408,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "3.2.2"
@@ -4769,6 +5418,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-buffer": "1.1.6"
@@ -4780,6 +5430,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "1.1.6"
@@ -4791,6 +5442,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4805,6 +5457,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4817,6 +5470,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
 				"lodash-es": "4.17.5",
@@ -4828,6 +5482,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
 			"integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+			"dev": true,
 			"requires": {
 				"lodash.isplainobject": "4.0.6"
 			}
@@ -4835,22 +5490,26 @@
 		"redux-observable": {
 			"version": "0.17.0",
 			"resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-0.17.0.tgz",
-			"integrity": "sha512-nVRl9KxdDNLKQRBkQK/svQIYDgTTDJbn3DEG6JB/DauZQs9bYl6R7b6ospXAS1zs6THarWHd3BhTTnGXFybVdA=="
+			"integrity": "sha512-nVRl9KxdDNLKQRBkQK/svQIYDgTTDJbn3DEG6JB/DauZQs9bYl6R7b6ospXAS1zs6THarWHd3BhTTnGXFybVdA==",
+			"dev": true
 		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -4861,6 +5520,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -4870,6 +5530,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -4879,12 +5540,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4892,30 +5555,35 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
 			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4924,6 +5592,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4932,12 +5601,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
@@ -4947,6 +5618,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -4954,12 +5626,14 @@
 		"rollup": {
 			"version": "0.55.5",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
-			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA=="
+			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
 			"integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+			"dev": true,
 			"requires": {
 				"rollup-pluginutils": "1.5.2"
 			}
@@ -4968,6 +5642,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -4977,6 +5652,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
 			}
@@ -4984,12 +5660,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
 			}
@@ -5012,33 +5690,39 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -5046,17 +5730,20 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
 			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
@@ -5071,6 +5758,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5080,17 +5768,20 @@
 		"sinon-chai": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
 			}
@@ -5098,12 +5789,14 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
 			}
@@ -5111,12 +5804,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5125,6 +5820,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -5133,12 +5829,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -5149,6 +5847,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -5156,22 +5855,26 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
@@ -5185,6 +5888,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5193,6 +5897,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -5203,6 +5908,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5212,22 +5918,26 @@
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
 			}
@@ -5235,17 +5945,20 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -5253,22 +5966,26 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+			"dev": true
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz",
 			"integrity": "sha1-kcV0146gW4HtgSRNUOww2CQMNW8=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"dts-bundle": "0.2.0",
@@ -5278,29 +5995,34 @@
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
 		"ua-parser-js": {
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5308,12 +6030,14 @@
 		"whatwg-fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5321,17 +6045,20 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5339,7 +6066,8 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		}
 	}
 }

--- a/packages/redux-subspace-observable/package.json
+++ b/packages/redux-subspace-observable/package.json
@@ -44,6 +44,7 @@
     "babel-cli": "^6.18.0",
     "babel-core": " ^6.7.7",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-function-bind": "^6.22.0",
     "babel-preset-env": "^1.6.1",

--- a/packages/redux-subspace-saga/.babelrc.js
+++ b/packages/redux-subspace-saga/.babelrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'stage-3',
   ],
   plugins: [
+    'annotate-pure-calls',
     cjs && 'transform-es2015-modules-commonjs',
     ['transform-runtime', {
       helpers: false,

--- a/packages/redux-subspace-saga/package-lock.json
+++ b/packages/redux-subspace-saga/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "redux-subspace-saga",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
 			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.40"
 			}
@@ -14,6 +17,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
 			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40",
 				"jsesc": "2.5.1",
@@ -25,7 +29,8 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"dev": true
 				}
 			}
 		},
@@ -33,6 +38,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
 			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.40",
 				"@babel/template": "7.0.0-beta.40",
@@ -43,6 +49,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
 			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40"
 			}
@@ -51,6 +58,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -61,6 +69,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -69,6 +78,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -79,6 +89,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -89,6 +100,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
 			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/types": "7.0.0-beta.40",
@@ -99,7 +111,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -107,6 +120,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
 			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/generator": "7.0.0-beta.40",
@@ -122,7 +136,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -143,6 +158,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
 			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -160,6 +176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
 			"requires": {
 				"samsam": "1.3.0"
 			}
@@ -167,12 +184,14 @@
 		"acorn": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -180,7 +199,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -188,6 +208,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.1.0",
@@ -198,27 +219,32 @@
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"micromatch": "2.3.11",
@@ -229,6 +255,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -237,6 +264,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
@@ -246,12 +274,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
 			"optional": true
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0"
@@ -261,6 +291,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -268,39 +299,46 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true,
 			"optional": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"babel-cli": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-polyfill": "6.26.0",
@@ -323,6 +361,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -333,6 +372,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -359,6 +399,7 @@
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/traverse": "7.0.0-beta.40",
@@ -371,7 +412,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -379,6 +421,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -394,6 +437,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -404,6 +448,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -414,6 +459,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -425,6 +471,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -436,6 +483,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -446,6 +494,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -458,6 +507,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -467,6 +517,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -476,6 +527,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -485,6 +537,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -495,6 +548,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -507,6 +561,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -520,6 +575,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -529,14 +585,25 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-annotate-pure-calls": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz",
+			"integrity": "sha512-0IP5H7eRCKPKcas8JCJf11c6OrSNmYmc3Ehaz+JFLasa4a2pLvfnfOeMBYMdqmutXjXcoqWA+H7ZyzHo008S/w==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -545,6 +612,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -552,42 +620,56 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -598,6 +680,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -608,6 +691,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -616,6 +700,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -624,6 +709,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0",
@@ -636,6 +722,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
@@ -652,6 +739,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -661,6 +749,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -669,6 +758,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -678,6 +768,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -686,6 +777,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -696,6 +788,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -704,6 +797,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -714,6 +808,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -725,6 +820,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -735,6 +831,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -745,6 +842,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.26.0"
@@ -754,6 +852,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -767,6 +866,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -776,6 +876,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -784,6 +885,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -794,6 +896,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -802,6 +905,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -810,6 +914,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -820,6 +925,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -830,6 +936,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -839,6 +946,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -848,6 +956,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -856,6 +965,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -866,6 +976,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -875,6 +986,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -884,6 +996,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.10.1"
 			}
@@ -892,6 +1005,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
 			"integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -900,6 +1014,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -909,6 +1024,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"core-js": "2.5.3",
@@ -918,7 +1034,8 @@
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -926,6 +1043,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -963,6 +1081,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -971,6 +1090,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -984,6 +1104,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -996,6 +1117,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -1019,6 +1141,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1031,6 +1154,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1047,6 +1171,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1057,23 +1182,27 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1083,6 +1212,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
@@ -1093,12 +1223,14 @@
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
 		},
 		"browserslist": {
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000813",
 				"electron-to-chromium": "1.3.36"
@@ -1108,6 +1240,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1115,17 +1248,20 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000813",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz",
-			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
+			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A==",
+			"dev": true
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"check-error": "1.0.2",
@@ -1139,6 +1275,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1150,17 +1287,20 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
@@ -1177,12 +1317,14 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
 			}
@@ -1190,17 +1332,20 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1208,22 +1353,26 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5",
@@ -1233,7 +1382,8 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.3",
@@ -1243,12 +1393,14 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-env": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.3.tgz",
 			"integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"is-windows": "1.0.2"
@@ -1258,6 +1410,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -1268,6 +1421,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1276,6 +1430,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1283,12 +1438,14 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1298,6 +1455,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1312,6 +1470,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1319,12 +1478,14 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
 			}
@@ -1333,6 +1494,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.2.0.tgz",
 			"integrity": "sha1-4WXklLAPgaO262Q4XL9tG0hrepk=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "0.2.0",
 				"glob": "4.5.3",
@@ -1343,6 +1505,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
 					"integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "0.1.0",
 						"minimist": "0.1.0"
@@ -1352,6 +1515,7 @@
 					"version": "4.5.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1363,6 +1527,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -1370,19 +1535,22 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
 		"electron-to-chromium": {
 			"version": "1.3.36",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
-			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
+			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -1391,6 +1559,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1403,6 +1572,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1412,12 +1582,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"eslint": {
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
@@ -1467,6 +1639,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -1475,6 +1648,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -1506,6 +1680,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -1516,6 +1691,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"dev": true,
 			"requires": {
 				"doctrine": "2.1.0",
 				"has": "1.0.1",
@@ -1527,6 +1703,7 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
 			"requires": {
 				"esrecurse": "4.2.1",
 				"estraverse": "4.2.0"
@@ -1535,12 +1712,14 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.5.1",
 				"acorn-jsx": "3.0.1"
@@ -1549,12 +1728,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1563,6 +1744,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1570,22 +1752,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
@@ -1595,6 +1781,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "2.2.3"
@@ -1604,6 +1791,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -1614,6 +1802,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
@@ -1622,22 +1811,26 @@
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fbjs": {
 			"version": "0.8.16",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"dev": true,
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -1651,7 +1844,8 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
 				}
 			}
 		},
@@ -1659,6 +1853,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
@@ -1667,6 +1862,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.3.0",
 				"object-assign": "4.1.1"
@@ -1676,12 +1872,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -1695,6 +1893,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1706,12 +1905,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
 			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
@@ -1720,22 +1921,26 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.9.2",
@@ -1745,11 +1950,13 @@
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1758,16 +1965,19 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1777,35 +1987,42 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1814,6 +2031,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1821,6 +2039,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1828,6 +2047,7 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1835,44 +2055,53 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -1880,6 +2109,7 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1888,6 +2118,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -1895,6 +2126,7 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1903,25 +2135,30 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1930,20 +2167,24 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -1953,11 +2194,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1968,6 +2211,7 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1978,6 +2222,7 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -1993,6 +2238,7 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -2001,6 +2247,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2008,6 +2255,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -2019,16 +2267,19 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -2038,11 +2289,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2052,11 +2305,13 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -2067,6 +2322,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -2074,16 +2330,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2091,20 +2350,24 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2113,16 +2376,19 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2131,16 +2397,19 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2152,17 +2421,20 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -2170,17 +2442,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2188,11 +2463,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -2211,6 +2488,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2220,6 +2498,7 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2230,21 +2509,25 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2252,16 +2535,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2270,30 +2556,36 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2305,6 +2597,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2312,6 +2605,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2325,6 +2619,7 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2354,32 +2649,38 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2387,6 +2688,7 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2403,6 +2705,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2410,6 +2713,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2417,6 +2721,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2426,11 +2731,13 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2438,11 +2745,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2452,6 +2761,7 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2467,6 +2777,7 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2475,6 +2786,7 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2483,25 +2795,30 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2510,6 +2827,7 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2517,34 +2835,40 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2558,6 +2882,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
@@ -2568,6 +2893,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2575,12 +2901,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2593,17 +2921,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -2612,6 +2943,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2619,17 +2951,20 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2638,22 +2973,26 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2662,12 +3001,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
 				"chalk": "2.3.2",
@@ -2688,12 +3029,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -2702,6 +3045,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -2712,6 +3056,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -2720,6 +3065,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -2730,6 +3076,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
 			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -2738,6 +3085,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
@@ -2746,28 +3094,33 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
@@ -2777,17 +3130,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
 			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2795,12 +3151,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2809,6 +3167,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -2817,12 +3176,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -2831,6 +3192,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -2839,23 +3201,27 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true,
 			"optional": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -2863,37 +3229,44 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -2903,6 +3276,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "1.7.3",
 				"whatwg-fetch": "2.0.3"
@@ -2911,12 +3285,14 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -2925,27 +3301,32 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsx-ast-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3"
 			}
@@ -2953,12 +3334,14 @@
 		"just-extend": {
 			"version": "1.1.27",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
@@ -2967,6 +3350,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -2975,32 +3359,38 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
 		},
 		"lodash-es": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
 		},
 		"lolex": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -3009,6 +3399,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3018,6 +3409,7 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
@@ -3038,12 +3430,14 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -3051,12 +3445,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3065,6 +3461,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
 			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
 				"commander": "2.11.0",
@@ -3081,12 +3478,14 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3094,12 +3493,14 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -3109,28 +3510,33 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
 			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"nise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
 			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3143,6 +3549,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -3152,6 +3559,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -3159,12 +3567,14 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nyc": {
 			"version": "11.4.1",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
 			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3198,6 +3608,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2",
 						"longest": "1.0.1",
@@ -3206,53 +3617,64 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -3262,6 +3684,7 @@
 				"babel-generator": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.26.0",
@@ -3276,6 +3699,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0"
 					}
@@ -3283,6 +3707,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "2.5.3",
 						"regenerator-runtime": "0.11.1"
@@ -3291,6 +3716,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"babel-traverse": "6.26.0",
@@ -3302,6 +3728,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.26.0",
 						"babel-messages": "6.23.0",
@@ -3317,6 +3744,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
@@ -3326,15 +3754,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3343,6 +3774,7 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3351,11 +3783,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -3365,11 +3799,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -3379,6 +3815,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3390,6 +3827,7 @@
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -3400,33 +3838,40 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "4.1.1",
 						"which": "1.3.0"
@@ -3435,21 +3880,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -3457,6 +3906,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -3464,21 +3914,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -3492,6 +3946,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "4.1.1",
 								"shebang-command": "1.2.0",
@@ -3503,6 +3958,7 @@
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3510,6 +3966,7 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -3517,17 +3974,20 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -3539,6 +3999,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -3548,17 +4009,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -3566,6 +4030,7 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -3573,19 +4038,23 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -3598,6 +4067,7 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -3606,21 +4076,25 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -3631,6 +4105,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -3640,25 +4115,30 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -3666,56 +4146,67 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3723,6 +4214,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3730,6 +4222,7 @@
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3737,48 +4230,58 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -3786,6 +4289,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.9.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "6.26.0",
 						"babel-template": "6.26.0",
@@ -3799,6 +4303,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.1",
 						"mkdirp": "0.5.1",
@@ -3809,6 +4314,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -3818,6 +4324,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.1.1",
@@ -3829,6 +4336,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -3838,21 +4346,25 @@
 				"istanbul-reports": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3860,11 +4372,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -3872,6 +4386,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -3883,6 +4398,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "2.0.0",
 						"path-exists": "3.0.0"
@@ -3890,21 +4406,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.2"
 					}
@@ -3912,6 +4432,7 @@
 				"lru-cache": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -3920,17 +4441,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "1.1.0"
 					}
@@ -3938,6 +4462,7 @@
 				"merge-source-map": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
 					}
@@ -3945,6 +4470,7 @@
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3963,33 +4489,39 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.5.0",
 						"is-builtin-module": "1.0.0",
@@ -4000,6 +4532,7 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.1.0"
 					}
@@ -4007,21 +4540,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -4030,6 +4567,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -4037,6 +4575,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -4044,11 +4583,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "0.7.0",
 						"lcid": "1.0.0",
@@ -4057,15 +4598,18 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "1.1.0"
 					}
@@ -4073,6 +4617,7 @@
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.3",
@@ -4083,6 +4628,7 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
@@ -4090,25 +4636,30 @@
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -4117,15 +4668,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -4133,6 +4687,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					},
@@ -4140,6 +4695,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4149,15 +4705,18 @@
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -4166,6 +4725,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -4173,6 +4733,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -4182,6 +4743,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -4191,6 +4753,7 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -4200,6 +4763,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -4208,6 +4772,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4217,49 +4782,59 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3"
 					}
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -4268,44 +4843,53 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"semver": {
 					"version": "5.4.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -4318,21 +4902,25 @@
 				"spdx-correct": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-license-ids": "1.2.2"
 					}
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4340,15 +4928,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -4358,6 +4949,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4365,21 +4957,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "2.3.11",
@@ -4390,15 +4986,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.7",
@@ -4409,6 +5008,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -4422,11 +5022,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "1.0.2",
 						"spdx-expression-parse": "1.0.4"
@@ -4435,26 +5037,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -4463,6 +5070,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -4473,11 +5081,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -4486,15 +5096,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
@@ -4513,6 +5126,7 @@
 						"cliui": {
 							"version": "3.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
@@ -4522,6 +5136,7 @@
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"code-point-at": "1.1.0",
 										"is-fullwidth-code-point": "1.0.0",
@@ -4535,13 +5150,15 @@
 				"yargs-parser": {
 					"version": "8.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -4550,17 +5167,20 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
@@ -4571,6 +5191,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4579,6 +5200,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -4587,6 +5209,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4599,17 +5222,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4620,6 +5246,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
@@ -4631,17 +5258,20 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -4649,29 +5279,34 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4679,38 +5314,45 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -4719,6 +5361,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -4728,12 +5371,14 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -4744,6 +5389,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "3.2.2"
@@ -4753,6 +5399,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-buffer": "1.1.6"
@@ -4764,6 +5411,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "1.1.6"
@@ -4775,6 +5423,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4789,6 +5438,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4801,6 +5451,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
 				"lodash-es": "4.17.5",
@@ -4812,6 +5463,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
 			"integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+			"dev": true,
 			"requires": {
 				"lodash.isplainobject": "4.0.6"
 			}
@@ -4819,17 +5471,20 @@
 		"redux-saga": {
 			"version": "0.16.0",
 			"resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.0.tgz",
-			"integrity": "sha1-CiMdsKFIkwHdmA9vL4jYztQY9yQ="
+			"integrity": "sha1-CiMdsKFIkwHdmA9vL4jYztQY9yQ=",
+			"dev": true
 		},
 		"redux-thunk": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-			"integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+			"integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU=",
+			"dev": true
 		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
@@ -4840,6 +5495,7 @@
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -4850,6 +5506,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -4859,6 +5516,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -4868,12 +5526,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4881,30 +5541,35 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
 			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4913,6 +5578,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4921,12 +5587,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
@@ -4936,6 +5604,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -4943,12 +5612,14 @@
 		"rollup": {
 			"version": "0.55.5",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
-			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA=="
+			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
 			"integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+			"dev": true,
 			"requires": {
 				"rollup-pluginutils": "1.5.2"
 			}
@@ -4957,6 +5628,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -4966,6 +5638,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
 			}
@@ -4973,12 +5646,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
 			}
@@ -4986,33 +5661,39 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -5020,17 +5701,20 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
 			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
@@ -5045,6 +5729,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5054,17 +5739,20 @@
 		"sinon-chai": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
 			}
@@ -5072,12 +5760,14 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
 			}
@@ -5085,12 +5775,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5099,6 +5791,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -5107,12 +5800,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -5123,6 +5818,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -5130,22 +5826,26 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
@@ -5159,6 +5859,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5167,6 +5868,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -5177,6 +5879,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5186,22 +5889,26 @@
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
 			}
@@ -5209,17 +5916,20 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -5227,22 +5937,26 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+			"dev": true
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz",
 			"integrity": "sha1-kcV0146gW4HtgSRNUOww2CQMNW8=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"dts-bundle": "0.2.0",
@@ -5252,29 +5966,34 @@
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
 		"ua-parser-js": {
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5282,12 +6001,14 @@
 		"whatwg-fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5295,17 +6016,20 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5313,7 +6037,8 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		}
 	}
 }

--- a/packages/redux-subspace-saga/package.json
+++ b/packages/redux-subspace-saga/package.json
@@ -42,6 +42,7 @@
     "babel-cli": "^6.18.0",
     "babel-core": " ^6.7.7",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",

--- a/packages/redux-subspace-wormhole/.babelrc.js
+++ b/packages/redux-subspace-wormhole/.babelrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'stage-3',
   ],
   plugins: [
+    'annotate-pure-calls',
     cjs && 'transform-es2015-modules-commonjs',
   ].filter(Boolean),
 }

--- a/packages/redux-subspace-wormhole/package-lock.json
+++ b/packages/redux-subspace-wormhole/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "redux-subspace-wormhole",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
 			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.40"
 			}
@@ -14,6 +17,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
 			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40",
 				"jsesc": "2.5.1",
@@ -25,7 +29,8 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"dev": true
 				}
 			}
 		},
@@ -33,6 +38,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
 			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.40",
 				"@babel/template": "7.0.0-beta.40",
@@ -43,6 +49,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
 			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40"
 			}
@@ -51,6 +58,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -61,6 +69,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -69,6 +78,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -79,6 +89,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -89,6 +100,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
 			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/types": "7.0.0-beta.40",
@@ -99,7 +111,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -107,6 +120,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
 			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/generator": "7.0.0-beta.40",
@@ -122,7 +136,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -143,6 +158,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
 			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -160,6 +176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
 			"requires": {
 				"samsam": "1.3.0"
 			}
@@ -167,12 +184,14 @@
 		"acorn": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -180,7 +199,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -188,6 +208,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.1.0",
@@ -198,27 +219,32 @@
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"micromatch": "2.3.11",
@@ -229,6 +255,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -237,6 +264,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
@@ -246,12 +274,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
 			"optional": true
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0"
@@ -261,6 +291,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -268,39 +299,46 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true,
 			"optional": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"babel-cli": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-polyfill": "6.26.0",
@@ -323,6 +361,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -333,6 +372,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -359,6 +399,7 @@
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/traverse": "7.0.0-beta.40",
@@ -371,7 +412,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -379,6 +421,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -394,6 +437,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -404,6 +448,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -414,6 +459,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -425,6 +471,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -436,6 +483,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -446,6 +494,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -458,6 +507,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -467,6 +517,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -476,6 +527,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -485,6 +537,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -495,6 +548,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -507,6 +561,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -520,6 +575,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -529,14 +585,25 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-annotate-pure-calls": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz",
+			"integrity": "sha512-0IP5H7eRCKPKcas8JCJf11c6OrSNmYmc3Ehaz+JFLasa4a2pLvfnfOeMBYMdqmutXjXcoqWA+H7ZyzHo008S/w==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -545,6 +612,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -552,42 +620,56 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -598,6 +680,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -608,6 +691,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -616,6 +700,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -624,6 +709,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0",
@@ -636,6 +722,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
@@ -652,6 +739,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -661,6 +749,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -669,6 +758,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -678,6 +768,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -686,6 +777,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -696,6 +788,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -704,6 +797,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -714,6 +808,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -725,6 +820,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -735,6 +831,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -745,6 +842,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.26.0"
@@ -754,6 +852,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -767,6 +866,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -776,6 +876,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -784,6 +885,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -794,6 +896,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -802,6 +905,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -810,6 +914,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -820,6 +925,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -830,6 +936,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -839,6 +946,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -848,6 +956,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -856,6 +965,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -866,6 +976,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -875,6 +986,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -884,6 +996,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.10.1"
 			}
@@ -892,6 +1005,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -901,6 +1015,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"core-js": "2.5.3",
@@ -910,7 +1025,8 @@
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -918,6 +1034,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -955,6 +1072,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -963,6 +1081,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -976,6 +1095,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -988,6 +1108,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -1002,6 +1123,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.5.3",
 				"regenerator-runtime": "0.11.1"
@@ -1011,6 +1133,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1023,6 +1146,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1039,6 +1163,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1049,23 +1174,27 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1075,6 +1204,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
@@ -1085,12 +1215,14 @@
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
 		},
 		"browserslist": {
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000813",
 				"electron-to-chromium": "1.3.36"
@@ -1100,6 +1232,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1107,17 +1240,20 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000813",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz",
-			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
+			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A==",
+			"dev": true
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"check-error": "1.0.2",
@@ -1131,6 +1267,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1142,17 +1279,20 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
@@ -1169,12 +1309,14 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
 			}
@@ -1182,17 +1324,20 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1200,22 +1345,26 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5",
@@ -1225,22 +1374,26 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-env": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.3.tgz",
 			"integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"is-windows": "1.0.2"
@@ -1250,6 +1403,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -1260,6 +1414,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1268,6 +1423,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1275,12 +1431,14 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1290,6 +1448,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1304,6 +1463,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1311,12 +1471,14 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
 			}
@@ -1325,6 +1487,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.2.0.tgz",
 			"integrity": "sha1-4WXklLAPgaO262Q4XL9tG0hrepk=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "0.2.0",
 				"glob": "4.5.3",
@@ -1335,6 +1498,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
 					"integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "0.1.0",
 						"minimist": "0.1.0"
@@ -1344,6 +1508,7 @@
 					"version": "4.5.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1355,6 +1520,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -1362,19 +1528,22 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
 		"electron-to-chromium": {
 			"version": "1.3.36",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
-			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
+			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -1383,6 +1552,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1395,6 +1565,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1404,12 +1575,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"eslint": {
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
@@ -1459,6 +1632,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -1467,6 +1641,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -1498,6 +1673,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -1508,6 +1684,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"dev": true,
 			"requires": {
 				"doctrine": "2.1.0",
 				"has": "1.0.1",
@@ -1519,6 +1696,7 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
 			"requires": {
 				"esrecurse": "4.2.1",
 				"estraverse": "4.2.0"
@@ -1527,12 +1705,14 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.5.1",
 				"acorn-jsx": "3.0.1"
@@ -1541,12 +1721,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1555,6 +1737,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1562,22 +1745,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
@@ -1587,6 +1774,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "2.2.3"
@@ -1596,6 +1784,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -1606,6 +1795,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
@@ -1614,22 +1804,26 @@
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fbjs": {
 			"version": "0.8.16",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"dev": true,
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -1643,7 +1837,8 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
 				}
 			}
 		},
@@ -1651,6 +1846,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
@@ -1659,6 +1855,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.3.0",
 				"object-assign": "4.1.1"
@@ -1668,12 +1865,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -1687,6 +1886,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1698,12 +1898,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
 			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
@@ -1712,22 +1914,26 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.9.2",
@@ -1737,11 +1943,13 @@
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1750,16 +1958,19 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1769,35 +1980,42 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1806,6 +2024,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1813,6 +2032,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1820,6 +2040,7 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1827,44 +2048,53 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -1872,6 +2102,7 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1880,6 +2111,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -1887,6 +2119,7 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1895,25 +2128,30 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1922,20 +2160,24 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -1945,11 +2187,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1960,6 +2204,7 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1970,6 +2215,7 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -1985,6 +2231,7 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1993,6 +2240,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2000,6 +2248,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -2011,16 +2260,19 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -2030,11 +2282,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2044,11 +2298,13 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -2059,6 +2315,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -2066,16 +2323,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2083,20 +2343,24 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2105,16 +2369,19 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2123,16 +2390,19 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2144,17 +2414,20 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -2162,17 +2435,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2180,11 +2456,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -2203,6 +2481,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2212,6 +2491,7 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2222,21 +2502,25 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2244,16 +2528,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2262,30 +2549,36 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2297,6 +2590,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2304,6 +2598,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2317,6 +2612,7 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2346,32 +2642,38 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2379,6 +2681,7 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2395,6 +2698,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2402,6 +2706,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2409,6 +2714,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2418,11 +2724,13 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2430,11 +2738,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2444,6 +2754,7 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2459,6 +2770,7 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2467,6 +2779,7 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2475,25 +2788,30 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2502,6 +2820,7 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2509,34 +2828,40 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2550,6 +2875,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
@@ -2560,6 +2886,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2567,12 +2894,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2585,17 +2914,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -2604,6 +2936,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2611,17 +2944,20 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2630,22 +2966,26 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2654,12 +2994,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
 				"chalk": "2.3.2",
@@ -2680,12 +3022,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -2694,6 +3038,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -2704,6 +3049,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -2712,6 +3058,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -2722,6 +3069,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
 			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -2730,6 +3078,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
@@ -2738,28 +3087,33 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
@@ -2769,17 +3123,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
 			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2787,12 +3144,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2801,6 +3160,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -2809,12 +3169,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -2823,6 +3185,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -2831,23 +3194,27 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true,
 			"optional": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -2855,37 +3222,44 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -2895,6 +3269,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "1.7.3",
 				"whatwg-fetch": "2.0.3"
@@ -2903,12 +3278,14 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -2917,27 +3294,32 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsx-ast-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3"
 			}
@@ -2945,12 +3327,14 @@
 		"just-extend": {
 			"version": "1.1.27",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
@@ -2959,6 +3343,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -2967,17 +3352,20 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
 		},
 		"lodash-es": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
@@ -2987,12 +3375,14 @@
 		"lolex": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -3001,6 +3391,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3010,6 +3401,7 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
@@ -3030,12 +3422,14 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -3043,12 +3437,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3057,6 +3453,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
 			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
 				"commander": "2.11.0",
@@ -3073,12 +3470,14 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3086,12 +3485,14 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -3101,28 +3502,33 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
 			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"nise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
 			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3135,6 +3541,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -3144,6 +3551,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -3151,12 +3559,14 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nyc": {
 			"version": "11.4.1",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
 			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3190,6 +3600,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2",
 						"longest": "1.0.1",
@@ -3198,53 +3609,64 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -3254,6 +3676,7 @@
 				"babel-generator": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.26.0",
@@ -3268,6 +3691,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0"
 					}
@@ -3275,6 +3699,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "2.5.3",
 						"regenerator-runtime": "0.11.1"
@@ -3283,6 +3708,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"babel-traverse": "6.26.0",
@@ -3294,6 +3720,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.26.0",
 						"babel-messages": "6.23.0",
@@ -3309,6 +3736,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
@@ -3318,15 +3746,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3335,6 +3766,7 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3343,11 +3775,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -3357,11 +3791,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -3371,6 +3807,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3382,6 +3819,7 @@
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -3392,33 +3830,40 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "4.1.1",
 						"which": "1.3.0"
@@ -3427,21 +3872,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -3449,6 +3898,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -3456,21 +3906,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -3484,6 +3938,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "4.1.1",
 								"shebang-command": "1.2.0",
@@ -3495,6 +3950,7 @@
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3502,6 +3958,7 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -3509,17 +3966,20 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -3531,6 +3991,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -3540,17 +4001,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -3558,6 +4022,7 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -3565,19 +4030,23 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -3590,6 +4059,7 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -3598,21 +4068,25 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -3623,6 +4097,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -3632,25 +4107,30 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -3658,56 +4138,67 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3715,6 +4206,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3722,6 +4214,7 @@
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3729,48 +4222,58 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -3778,6 +4281,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.9.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "6.26.0",
 						"babel-template": "6.26.0",
@@ -3791,6 +4295,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.1",
 						"mkdirp": "0.5.1",
@@ -3801,6 +4306,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -3810,6 +4316,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.1.1",
@@ -3821,6 +4328,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -3830,21 +4338,25 @@
 				"istanbul-reports": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3852,11 +4364,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -3864,6 +4378,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -3875,6 +4390,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "2.0.0",
 						"path-exists": "3.0.0"
@@ -3882,21 +4398,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.2"
 					}
@@ -3904,6 +4424,7 @@
 				"lru-cache": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -3912,17 +4433,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "1.1.0"
 					}
@@ -3930,6 +4454,7 @@
 				"merge-source-map": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
 					}
@@ -3937,6 +4462,7 @@
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3955,33 +4481,39 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.5.0",
 						"is-builtin-module": "1.0.0",
@@ -3992,6 +4524,7 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.1.0"
 					}
@@ -3999,21 +4532,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -4022,6 +4559,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -4029,6 +4567,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -4036,11 +4575,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "0.7.0",
 						"lcid": "1.0.0",
@@ -4049,15 +4590,18 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "1.1.0"
 					}
@@ -4065,6 +4609,7 @@
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.3",
@@ -4075,6 +4620,7 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
@@ -4082,25 +4628,30 @@
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -4109,15 +4660,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -4125,6 +4679,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					},
@@ -4132,6 +4687,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4141,15 +4697,18 @@
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -4158,6 +4717,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -4165,6 +4725,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -4174,6 +4735,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -4183,6 +4745,7 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -4192,6 +4755,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -4200,6 +4764,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4209,49 +4774,59 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3"
 					}
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -4260,44 +4835,53 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"semver": {
 					"version": "5.4.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -4310,21 +4894,25 @@
 				"spdx-correct": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-license-ids": "1.2.2"
 					}
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4332,15 +4920,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -4350,6 +4941,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4357,21 +4949,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "2.3.11",
@@ -4382,15 +4978,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.7",
@@ -4401,6 +5000,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -4414,11 +5014,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "1.0.2",
 						"spdx-expression-parse": "1.0.4"
@@ -4427,26 +5029,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -4455,6 +5062,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -4465,11 +5073,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -4478,15 +5088,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
@@ -4505,6 +5118,7 @@
 						"cliui": {
 							"version": "3.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
@@ -4514,6 +5128,7 @@
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"code-point-at": "1.1.0",
 										"is-fullwidth-code-point": "1.0.0",
@@ -4527,13 +5142,15 @@
 				"yargs-parser": {
 					"version": "8.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -4542,17 +5159,20 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
@@ -4563,6 +5183,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4571,6 +5192,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -4579,6 +5201,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4591,17 +5214,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4612,6 +5238,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
@@ -4623,17 +5250,20 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -4641,29 +5271,34 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4671,38 +5306,45 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -4711,6 +5353,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -4720,12 +5363,14 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -4736,6 +5381,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "3.2.2"
@@ -4745,6 +5391,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-buffer": "1.1.6"
@@ -4756,6 +5403,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "1.1.6"
@@ -4767,6 +5415,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4781,6 +5430,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4793,6 +5443,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
 				"lodash-es": "4.17.5",
@@ -4804,6 +5455,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
 			"integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+			"dev": true,
 			"requires": {
 				"lodash.isplainobject": "4.0.6"
 			}
@@ -4811,17 +5463,20 @@
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -4832,6 +5487,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -4841,6 +5497,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -4850,12 +5507,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4863,30 +5522,35 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
 			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4895,6 +5559,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4903,12 +5568,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
@@ -4918,6 +5585,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -4925,12 +5593,14 @@
 		"rollup": {
 			"version": "0.55.5",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
-			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA=="
+			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
 			"integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+			"dev": true,
 			"requires": {
 				"rollup-pluginutils": "1.5.2"
 			}
@@ -4939,6 +5609,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -4948,6 +5619,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
 			}
@@ -4955,12 +5627,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
 			}
@@ -4968,33 +5642,39 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -5002,17 +5682,20 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
 			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
@@ -5027,6 +5710,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5036,17 +5720,20 @@
 		"sinon-chai": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
 			}
@@ -5054,12 +5741,14 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
 			}
@@ -5067,12 +5756,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5081,6 +5772,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -5089,12 +5781,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -5105,6 +5799,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -5112,22 +5807,26 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
@@ -5141,6 +5840,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5149,6 +5849,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -5159,6 +5860,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5168,22 +5870,26 @@
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
 			}
@@ -5191,17 +5897,20 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -5209,22 +5918,26 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+			"dev": true
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz",
 			"integrity": "sha1-kcV0146gW4HtgSRNUOww2CQMNW8=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"dts-bundle": "0.2.0",
@@ -5234,29 +5947,34 @@
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
 		"ua-parser-js": {
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5264,12 +5982,14 @@
 		"whatwg-fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5277,17 +5997,20 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5295,7 +6018,8 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		}
 	}
 }

--- a/packages/redux-subspace-wormhole/package.json
+++ b/packages/redux-subspace-wormhole/package.json
@@ -38,6 +38,7 @@
     "babel-cli": "^6.18.0",
     "babel-core": " ^6.7.7",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.5.0",

--- a/packages/redux-subspace/.babelrc.js
+++ b/packages/redux-subspace/.babelrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'stage-3',
   ],
   plugins: [
+	'annotate-pure-calls',
     cjs && 'transform-es2015-modules-commonjs',
   ].filter(Boolean),
 }

--- a/packages/redux-subspace/package-lock.json
+++ b/packages/redux-subspace/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "redux-subspace",
+	"version": "2.4.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
 			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.40"
 			}
@@ -14,6 +17,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
 			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40",
 				"jsesc": "2.5.1",
@@ -25,7 +29,8 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"dev": true
 				}
 			}
 		},
@@ -33,6 +38,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
 			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.40",
 				"@babel/template": "7.0.0-beta.40",
@@ -43,6 +49,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
 			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.40"
 			}
@@ -51,6 +58,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
 			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -61,6 +69,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -69,6 +78,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -79,6 +89,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -89,6 +100,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
 			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/types": "7.0.0-beta.40",
@@ -99,7 +111,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -107,6 +120,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
 			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/generator": "7.0.0-beta.40",
@@ -122,7 +136,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -143,6 +158,7 @@
 			"version": "7.0.0-beta.40",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
 			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -160,6 +176,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
 			"requires": {
 				"samsam": "1.3.0"
 			}
@@ -167,12 +184,14 @@
 		"acorn": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -180,7 +199,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -188,6 +208,7 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.1.0",
@@ -198,27 +219,32 @@
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"micromatch": "2.3.11",
@@ -229,6 +255,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -237,6 +264,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
@@ -246,12 +274,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true,
 			"optional": true
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0"
@@ -261,6 +291,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -268,39 +299,46 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true,
 			"optional": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"babel-cli": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-polyfill": "6.26.0",
@@ -323,6 +361,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -333,6 +372,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -359,6 +399,7 @@
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.40",
 				"@babel/traverse": "7.0.0-beta.40",
@@ -371,7 +412,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.40",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+					"dev": true
 				}
 			}
 		},
@@ -379,6 +421,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -394,6 +437,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -404,6 +448,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -414,6 +459,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -425,6 +471,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -436,6 +483,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -446,6 +494,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -458,6 +507,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -467,6 +517,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -476,6 +527,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -485,6 +537,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -495,6 +548,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -507,6 +561,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -520,6 +575,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -529,14 +585,25 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-annotate-pure-calls": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz",
+			"integrity": "sha512-0IP5H7eRCKPKcas8JCJf11c6OrSNmYmc3Ehaz+JFLasa4a2pLvfnfOeMBYMdqmutXjXcoqWA+H7ZyzHo008S/w==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-dynamic-import": "6.18.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -545,6 +612,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -552,42 +620,56 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
+		"babel-plugin-syntax-dynamic-import": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -598,6 +680,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -608,6 +691,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -616,6 +700,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -624,6 +709,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0",
@@ -636,6 +722,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
@@ -652,6 +739,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
@@ -661,6 +749,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -669,6 +758,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -678,6 +768,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -686,6 +777,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -696,6 +788,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -704,6 +797,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -714,6 +808,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -725,6 +820,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -735,6 +831,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -745,6 +842,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.26.0"
@@ -754,6 +852,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -767,6 +866,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -776,6 +876,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -784,6 +885,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -794,6 +896,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -802,6 +905,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -810,6 +914,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -820,6 +925,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -830,6 +936,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -839,6 +946,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.26.0"
@@ -848,6 +956,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -856,6 +965,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -866,6 +976,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -875,6 +986,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.26.0"
@@ -884,6 +996,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.10.1"
 			}
@@ -892,6 +1005,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -901,6 +1015,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"core-js": "2.5.3",
@@ -910,7 +1025,8 @@
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -918,6 +1034,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -955,6 +1072,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -963,6 +1081,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -976,6 +1095,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -988,6 +1108,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -1002,6 +1123,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.5.3",
 				"regenerator-runtime": "0.11.1"
@@ -1011,6 +1133,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1023,6 +1146,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1039,6 +1163,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1049,23 +1174,27 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1075,6 +1204,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"expand-range": "1.8.2",
@@ -1085,12 +1215,14 @@
 		"browser-stdout": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
 		},
 		"browserslist": {
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000813",
 				"electron-to-chromium": "1.3.36"
@@ -1100,6 +1232,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1107,17 +1240,20 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000813",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz",
-			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A=="
+			"integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A==",
+			"dev": true
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"check-error": "1.0.2",
@@ -1131,6 +1267,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1142,17 +1279,20 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
@@ -1169,12 +1309,14 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
 			}
@@ -1182,17 +1324,20 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1200,22 +1345,26 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5",
@@ -1225,22 +1374,26 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-env": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.3.tgz",
 			"integrity": "sha512-UOokgwvDzCT0mqRSLEkJzUhYXB1vK3E5UgDrD41QiXsm9UetcW2rCGHYz/O3p873lMJ1VZbFCF9Izkwh7nYR5A==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"is-windows": "1.0.2"
@@ -1250,6 +1403,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -1260,6 +1414,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1268,6 +1423,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1275,12 +1431,14 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1290,6 +1448,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1304,6 +1463,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1311,12 +1471,14 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
 			}
@@ -1325,6 +1487,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dts-bundle/-/dts-bundle-0.2.0.tgz",
 			"integrity": "sha1-4WXklLAPgaO262Q4XL9tG0hrepk=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "0.2.0",
 				"glob": "4.5.3",
@@ -1335,6 +1498,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.2.0.tgz",
 					"integrity": "sha1-BCkUSYl5rC2fPHPk/z5od9O8krY=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "0.1.0",
 						"minimist": "0.1.0"
@@ -1344,6 +1508,7 @@
 					"version": "4.5.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1355,6 +1520,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -1362,19 +1528,22 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
 		"electron-to-chromium": {
 			"version": "1.3.36",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
-			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
+			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -1383,6 +1552,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1395,6 +1565,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1404,12 +1575,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"eslint": {
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
@@ -1459,6 +1632,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -1467,6 +1641,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -1498,6 +1673,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -1508,6 +1684,7 @@
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"dev": true,
 			"requires": {
 				"doctrine": "2.1.0",
 				"has": "1.0.1",
@@ -1519,6 +1696,7 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
 			"requires": {
 				"esrecurse": "4.2.1",
 				"estraverse": "4.2.0"
@@ -1527,12 +1705,14 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
 			"requires": {
 				"acorn": "5.5.1",
 				"acorn-jsx": "3.0.1"
@@ -1541,12 +1721,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1555,6 +1737,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1562,22 +1745,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
@@ -1587,6 +1774,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "2.2.3"
@@ -1596,6 +1784,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -1606,6 +1795,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-extglob": "1.0.0"
@@ -1614,22 +1804,26 @@
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fbjs": {
 			"version": "0.8.16",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"dev": true,
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -1643,7 +1837,8 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
 				}
 			}
 		},
@@ -1651,6 +1846,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
@@ -1659,6 +1855,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.3.0",
 				"object-assign": "4.1.1"
@@ -1668,12 +1865,14 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "2.1.0",
@@ -1687,6 +1886,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1698,6 +1898,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.1.tgz",
 			"integrity": "sha1-bzQhG5SDTqHDzDD056+tPQ+/caI=",
+			"dev": true,
 			"requires": {
 				"lodash.isplainobject": "3.2.0"
 			},
@@ -1706,6 +1907,7 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
 					"integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+					"dev": true,
 					"requires": {
 						"lodash._basefor": "3.0.3",
 						"lodash.isarguments": "3.1.0",
@@ -1718,12 +1920,14 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
 			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "1.0.2"
@@ -1732,22 +1936,26 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.9.2",
@@ -1757,11 +1965,13 @@
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1770,16 +1980,19 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1789,35 +2002,42 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1826,6 +2046,7 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1833,6 +2054,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1840,6 +2062,7 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1847,44 +2070,53 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -1892,6 +2124,7 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1900,6 +2133,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -1907,6 +2141,7 @@
 				"debug": {
 					"version": "2.6.8",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1915,25 +2150,30 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1942,20 +2182,24 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -1965,11 +2209,13 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1980,6 +2226,7 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1990,6 +2237,7 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -2005,6 +2253,7 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -2013,6 +2262,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2020,6 +2270,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -2031,16 +2282,19 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -2050,11 +2304,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -2064,11 +2320,13 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -2079,6 +2337,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -2086,16 +2345,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -2103,20 +2365,24 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -2125,16 +2391,19 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -2143,16 +2412,19 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -2164,17 +2436,20 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -2182,17 +2457,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2200,11 +2478,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -2223,6 +2503,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2232,6 +2513,7 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2242,21 +2524,25 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2264,16 +2550,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2282,30 +2571,36 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2317,6 +2612,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2324,6 +2620,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2337,6 +2634,7 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2366,32 +2664,38 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2399,6 +2703,7 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2415,6 +2720,7 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2422,6 +2728,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2429,6 +2736,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2438,11 +2746,13 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2450,11 +2760,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2464,6 +2776,7 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2479,6 +2792,7 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2487,6 +2801,7 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2495,25 +2810,30 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2522,6 +2842,7 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2529,34 +2850,40 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz",
-			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE="
+			"integrity": "sha1-WZivJKr8gC0VyCxoVlfuuLENSpE=",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2570,6 +2897,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "2.0.0",
@@ -2580,6 +2908,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2587,12 +2916,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2605,17 +2936,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.1"
 			}
@@ -2624,6 +2958,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2631,17 +2966,20 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2650,22 +2988,26 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2674,12 +3016,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
 				"chalk": "2.3.2",
@@ -2700,12 +3044,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -2714,6 +3060,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -2724,6 +3071,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -2732,6 +3080,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -2742,6 +3091,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
 			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -2750,6 +3100,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
@@ -2758,28 +3109,33 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "2.0.0"
@@ -2789,17 +3145,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
 			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2807,12 +3166,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2821,6 +3182,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"kind-of": "3.2.2"
@@ -2829,12 +3191,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -2843,6 +3207,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -2851,23 +3216,27 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true,
 			"optional": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -2875,37 +3244,44 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"isarray": "1.0.0"
@@ -2915,6 +3291,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "1.7.3",
 				"whatwg-fetch": "2.0.3"
@@ -2923,12 +3300,14 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -2937,27 +3316,32 @@
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsx-ast-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"dev": true,
 			"requires": {
 				"array-includes": "3.0.3"
 			}
@@ -2965,12 +3349,14 @@
 		"just-extend": {
 			"version": "1.1.27",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
@@ -2979,6 +3365,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -2987,42 +3374,50 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
 		},
 		"lodash-es": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+			"dev": true
 		},
 		"lodash._basefor": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-			"integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+			"integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
 		},
 		"lodash.isarray": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
 		},
 		"lodash.keysin": {
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
 			"integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+			"dev": true,
 			"requires": {
 				"lodash.isarguments": "3.1.0",
 				"lodash.isarray": "3.0.4"
@@ -3031,12 +3426,14 @@
 		"lolex": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -3045,6 +3442,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3054,6 +3452,7 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"arr-diff": "2.0.0",
@@ -3074,12 +3473,14 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -3087,12 +3488,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3101,6 +3504,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
 			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.0",
 				"commander": "2.11.0",
@@ -3117,12 +3521,14 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3130,12 +3536,14 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -3145,28 +3553,33 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
 			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
 			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"nise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
 			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3179,6 +3592,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -3188,6 +3602,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -3195,12 +3610,14 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nyc": {
 			"version": "11.4.1",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
 			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3234,6 +3651,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2",
 						"longest": "1.0.1",
@@ -3242,53 +3660,64 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -3298,6 +3727,7 @@
 				"babel-generator": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.26.0",
@@ -3312,6 +3742,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0"
 					}
@@ -3319,6 +3750,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "2.5.3",
 						"regenerator-runtime": "0.11.1"
@@ -3327,6 +3759,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"babel-traverse": "6.26.0",
@@ -3338,6 +3771,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.26.0",
 						"babel-messages": "6.23.0",
@@ -3353,6 +3787,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
@@ -3362,15 +3797,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.8",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3379,6 +3817,7 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -3387,11 +3826,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -3401,11 +3842,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -3415,6 +3858,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -3426,6 +3870,7 @@
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -3436,33 +3881,40 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "4.1.1",
 						"which": "1.3.0"
@@ -3471,21 +3923,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -3493,6 +3949,7 @@
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -3500,21 +3957,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -3528,6 +3989,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "4.1.1",
 								"shebang-command": "1.2.0",
@@ -3539,6 +4001,7 @@
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -3546,6 +4009,7 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -3553,17 +4017,20 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -3575,6 +4042,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -3584,17 +4052,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -3602,6 +4073,7 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -3609,19 +4081,23 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -3634,6 +4110,7 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -3642,21 +4119,25 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -3667,6 +4148,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -3676,25 +4158,30 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -3702,56 +4189,67 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3759,6 +4257,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3766,6 +4265,7 @@
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -3773,48 +4273,58 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -3822,6 +4332,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.9.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "6.26.0",
 						"babel-template": "6.26.0",
@@ -3835,6 +4346,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.1",
 						"mkdirp": "0.5.1",
@@ -3845,6 +4357,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -3854,6 +4367,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.1.1",
@@ -3865,6 +4379,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -3874,21 +4389,25 @@
 				"istanbul-reports": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -3896,11 +4415,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -3908,6 +4429,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -3919,6 +4441,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "2.0.0",
 						"path-exists": "3.0.0"
@@ -3926,21 +4449,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.2"
 					}
@@ -3948,6 +4475,7 @@
 				"lru-cache": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -3956,17 +4484,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "1.1.0"
 					}
@@ -3974,6 +4505,7 @@
 				"merge-source-map": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
 					}
@@ -3981,6 +4513,7 @@
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -3999,33 +4532,39 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.5.0",
 						"is-builtin-module": "1.0.0",
@@ -4036,6 +4575,7 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.1.0"
 					}
@@ -4043,21 +4583,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -4066,6 +4610,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -4073,6 +4618,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -4080,11 +4626,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "0.7.0",
 						"lcid": "1.0.0",
@@ -4093,15 +4641,18 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "1.1.0"
 					}
@@ -4109,6 +4660,7 @@
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.3",
@@ -4119,6 +4671,7 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
@@ -4126,25 +4679,30 @@
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -4153,15 +4711,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -4169,6 +4730,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					},
@@ -4176,6 +4738,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4185,15 +4748,18 @@
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -4202,6 +4768,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -4209,6 +4776,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -4218,6 +4786,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -4227,6 +4796,7 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -4236,6 +4806,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -4244,6 +4815,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -4253,49 +4825,59 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3"
 					}
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -4304,44 +4886,53 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"semver": {
 					"version": "5.4.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -4354,21 +4945,25 @@
 				"spdx-correct": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-license-ids": "1.2.2"
 					}
 				},
 				"spdx-expression-parse": {
 					"version": "1.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-license-ids": {
 					"version": "1.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4376,15 +4971,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -4394,6 +4992,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4401,21 +5000,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "2.3.11",
@@ -4426,15 +5029,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.7",
@@ -4445,6 +5051,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -4458,11 +5065,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "1.0.2",
 						"spdx-expression-parse": "1.0.4"
@@ -4471,26 +5080,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -4499,6 +5113,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -4509,11 +5124,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -4522,15 +5139,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
@@ -4549,6 +5169,7 @@
 						"cliui": {
 							"version": "3.2.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
@@ -4558,6 +5179,7 @@
 								"string-width": {
 									"version": "1.0.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"code-point-at": "1.1.0",
 										"is-fullwidth-code-point": "1.0.0",
@@ -4571,13 +5193,15 @@
 				"yargs-parser": {
 					"version": "8.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -4586,17 +5210,20 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "0.1.5",
@@ -4607,6 +5234,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4615,6 +5243,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -4623,6 +5252,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4635,17 +5265,20 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4656,6 +5289,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "0.3.0",
@@ -4667,17 +5301,20 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -4685,29 +5322,34 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4715,38 +5357,45 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -4755,6 +5404,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -4764,12 +5414,14 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "3.0.0",
@@ -4780,6 +5432,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "3.2.2"
@@ -4789,6 +5442,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"is-buffer": "1.1.6"
@@ -4800,6 +5454,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "1.1.6"
@@ -4811,6 +5466,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4825,6 +5481,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4837,6 +5494,7 @@
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
 				"lodash-es": "4.17.5",
@@ -4848,6 +5506,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
 			"integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+			"dev": true,
 			"requires": {
 				"lodash.isplainobject": "4.0.6"
 			}
@@ -4856,6 +5515,7 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/redux-promise/-/redux-promise-0.5.3.tgz",
 			"integrity": "sha1-6X5snTvzdurLebq+bZBtogES1tg=",
+			"dev": true,
 			"requires": {
 				"flux-standard-action": "0.6.1"
 			}
@@ -4863,22 +5523,26 @@
 		"redux-thunk": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-			"integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+			"integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU=",
+			"dev": true
 		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -4889,6 +5553,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
@@ -4898,6 +5563,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -4907,12 +5573,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4920,30 +5588,35 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
 			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4952,6 +5625,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4960,12 +5634,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
@@ -4975,6 +5651,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -4982,12 +5659,14 @@
 		"rollup": {
 			"version": "0.55.5",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
-			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA=="
+			"integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
 			"integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+			"dev": true,
 			"requires": {
 				"rollup-pluginutils": "1.5.2"
 			}
@@ -4996,6 +5675,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -5005,6 +5685,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
 			}
@@ -5012,12 +5693,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
 			}
@@ -5025,33 +5708,39 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -5059,17 +5748,20 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
 			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
@@ -5084,6 +5776,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5093,17 +5786,20 @@
 		"sinon-chai": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
 			}
@@ -5111,12 +5807,14 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.7"
 			}
@@ -5124,12 +5822,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5138,6 +5838,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -5146,12 +5847,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -5162,6 +5865,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -5169,22 +5873,26 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"ajv-keywords": "2.1.1",
@@ -5198,6 +5906,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5206,6 +5915,7 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -5216,6 +5926,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5225,22 +5936,26 @@
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
 			}
@@ -5248,17 +5963,20 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -5266,22 +5984,26 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+			"dev": true
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz",
 			"integrity": "sha1-kcV0146gW4HtgSRNUOww2CQMNW8=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "1.1.0",
 				"dts-bundle": "0.2.0",
@@ -5291,29 +6013,34 @@
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
 		"ua-parser-js": {
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+			"dev": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5321,12 +6048,14 @@
 		"whatwg-fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5334,17 +6063,20 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5352,7 +6084,8 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		}
 	}
 }

--- a/packages/redux-subspace/package.json
+++ b/packages/redux-subspace/package.json
@@ -37,6 +37,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
…bility

| Q                       | A 
| ----------------------- | ---
| Fixed Issues?           | Fixes #84,
| Documentation only PR   | <!--(Can use an emoji 👍) -->
| Patch: Bug Fix?         | <!--(Can use an emoji 👍) -->
| Minor: New Feature?     | 👍
| Major: Breaking Change? | <!--(Can use an emoji 👍) -->
| Tests Added + Pass?     | Yes

Truth to be told only 2 packages **at the moment** benefit from it.

`redux-subspace-loop` - `namespaced` export is created by a call and it might get dropped if the package stays unused

`react-redux-subspace` - `SubspaceProvider` gets correctly annotated, but it cannot be removed because it uses static properties, so the output looks like this:
```js
var SubspaceProvider = /*#__PURE__*/function (_React$PureComponent) {
 // ...
}(React__default.PureComponent);

SubspaceProvider.propTypes = {
    children: PropTypes.element.isRequired,
    mapState: /*#__PURE__*/PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
    namespace: PropTypes.string,
    subspaceDecorator: PropTypes.func
};

SubspaceProvider.contextTypes = {
    store: PropTypes.object.isRequired
};

SubspaceProvider.childContextTypes = {
    store: PropTypes.object
};
```

Unfortunately such static assignments prevent dead code removal, because algorithm thinks that `SubspaceProvider` is used.

There are 2 ways of "fixing" this problem:
- custom babel plugin to pull those static assignments into the transpiled class IIFE, I might create it some day, but in general would like to fix it upstream - I have working PR for this in babel@7, but it's not merged in et
- create this class from the IIFE, like this:
```js
const SubspaceProvider = (() => {
  class SubspaceProvider extends React.PureComponent {
    // ...
  }
  return SubspaceProvider
})()
export default SubspaceProvider
```
this will let the plugin annotate outer IIFE (inner being a transpiled class) which would contain whole class definition and thus making it dead code droppable.

But ofc this is somewhat ugly and also gives rather rly small benefits - in real world scenarios for this library probably even none.
