### PR TITLE
update peerDependency

### DIFF
--- a/packages/react-redux-subspace/package.json
+++ b/packages/react-redux-subspace/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0",
-    "react-redux": "^6.0.0 || ^7.0.0",
+    "react-redux": "^7.0.0",
     "redux": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Related to this [issue](https://github.com/ioof-holdings/redux-subspace/issues/121).

| Q                       | A 
| ----------------------- | ---
| Fixed Issues?           | [Compatibility issue with react-redux v6](https://github.com/ioof-holdings/redux-subspace/issues/121)
| Patch: Bug Fix?         | No
| Major: Breaking Change? | Might be

Update the peer dependency which should at least give user a warning in case `react-redux@^6.0.0` is used