### PR TITLE
Fix issue where wormholes create new state objects when the state has not changed

### DIFF
--- a/packages/redux-subspace-wormhole/package.json
+++ b/packages/redux-subspace-wormhole/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "lodash.isplainobject": "^4.0.6",
+    "memoize-one": "^5.1.1",
     "redux-subspace": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/redux-subspace-wormhole/test/wormhole-spec.js
+++ b/packages/redux-subspace-wormhole/test/wormhole-spec.js
@@ -51,6 +51,60 @@ describe('wormhole Tests', () => {
         expect(state).to.deep.equal({ original: "test", extra: "expected" })
     })
 
+    it('should return same state reference and wormhole value if state is unchanged', () => {
+        const store = {
+            rootStore: {
+                getState: () => ({ value: "expected" })
+            }
+        }
+
+        const state = { original: "test" }
+        const getState = () => state
+
+        const middleware = wormhole((state) => state.value, 'extra')(store).getState(getState)
+
+        const state1 = middleware()
+        const state2 = middleware()
+
+        expect(state1).to.equal(state2)
+    })
+
+    it('should not break change state reference when middleware is applied to multiple stores', () => {
+        const store1 = {
+            rootStore: {
+                getState: () => ({ value: "expected" })
+            }
+        }
+
+        const state1 = { original: "test1" }
+        const getState1 = () => state1
+
+        const store2 = {
+            rootStore: {
+                getState: () => ({ value: "expected" })
+            }
+        }
+
+        const state2 = { original: "test2" }
+        const getState2 = () => state2
+        
+        const middlewareCreator = wormhole((state) => state.value, 'extra')
+
+        const middleware1 = middlewareCreator(store1).getState(getState1)
+        const middleware2 = middlewareCreator(store1).getState(getState2)
+
+        const state11 = middleware1()
+        const state21 = middleware2()
+        const state12 = middleware1()
+        const state22 = middleware2()
+
+        expect(state11).to.equal(state12)
+        expect(state21).to.equal(state22)
+
+        expect(state11).to.not.equal(state21)
+        expect(state12).to.not.equal(state22)
+    })
+
     it('should handle array state', () => {
         const store = {
             rootStore: {


### PR DESCRIPTION
<!--
Thanks for contributing to redux-subspace!

Before making a PR please make sure to read our contributing guidelines
https://github.com/ioof-holdings/redux-subspace/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                       | A 
| ----------------------- | ---
| Fixed Issues?           | 
| Documentation only PR   | 
| Patch: Bug Fix?         | 
| Minor: New Feature?     | 👍
| Major: Breaking Change? | 
| Tests Added + Pass?     | Yes

<!-- Describe your changes below in as much detail as possible -->

In a similar vein to #137, this is an optimisation to reduce the chance of triggering unnecessary rerenders because things appear to be changing, when in reality, nothing is changing at all.

In this case, the current implementation of `redux-subspace-wormhole` will create a new state object each time `getState` is called, even if the state of the subspace and the mapped wormhole state (generally fairly static values) don't change.

Other than just being _more correct_ about how we deal with Redux's state object, the most common reason why `getState` would be and neither of these two values has changed is if another subspace dispatched an action and updated it's state, all the connected components will call `getState` to see if they need to rerender.

Generally, the cost of this is fairly low as the `mapStateToProps` would shallowly equal the previous render and the usual `connect` optimisations would kick in, but in cases where non-pure component are being used, or when `mapStateToProps` is particularly expensive, this could still pose an issue.

There's also more to Redux than just `react-redux` and we can't know that other parts of the ecosystem don't rely on the referential equality of `getState` when nothing changes, so we should be good citizens and not break that contract.

I guess it's worth mentioning that I did add an additional dependency to `redux-subspace-wormhole`, being `memoize-one`.  I felt the benefit of not having to write and maintain the memoize functionality myself was worth it for [the cost of that package](https://bundlephobia.com/result?p=memoize-one@5.1.1) and it's fairly common in the react/redux/modern js world that it's likely to already be in people's bundles anyway.

<!-- Don't forget to [add yourself as a contributor](https://github.com/ioof-holdings/redux-subspace/blob/master/CONTRIBUTING.md#add-yourself-as-a-contributor) if you're not already -->
